### PR TITLE
Add domain event dispatcher infrastructure

### DIFF
--- a/App/CompositionRoot.swift
+++ b/App/CompositionRoot.swift
@@ -5,6 +5,7 @@ import SwiftData
 final class CompositionRoot: ObservableObject {
     let persistence: PersistenceController
     let appStore: AppStore
+    let eventDispatcher: EventDispatcher
 
     var modelContainer: ModelContainer { persistence.modelContainer }
 
@@ -17,7 +18,10 @@ final class CompositionRoot: ObservableObject {
         }
         self.persistence = persistence
 
-        let services = ServiceContainer(persistence: persistence)
+        let eventDispatcher = EventDispatcher()
+        self.eventDispatcher = eventDispatcher
+
+        let services = ServiceContainer(persistence: persistence, eventDispatcher: eventDispatcher)
         let syncService = SyncService()
         let reducer = AppReducer(services: services, persistence: persistence, syncService: syncService)
         self.appStore = AppStore(initialState: AppState(), reducer: reducer)

--- a/Core/Events/DomainEvent.swift
+++ b/Core/Events/DomainEvent.swift
@@ -1,0 +1,56 @@
+import Combine
+import Foundation
+
+enum DomainEventKind: String {
+    case receiptScanned = "receipt.scanned"
+    case barcodeScanned = "barcode.scanned"
+    case inventoryAdded = "inventory.added"
+    case inventoryAdjusted = "inventory.adjusted"
+    case inventoryLow = "inventory.low"
+    case shoppingChecked = "shopping.checked"
+    case shoppingCreated = "shopping.created"
+    case transactionLogged = "transaction.logged"
+    case accountCsvImported = "account.csvImported"
+    case habitStarted = "habit.started"
+    case habitTicked = "habit.ticked"
+    case habitCompleted = "habit.completed"
+    case habitSkipped = "habit.skipped"
+    case calendarEventLinked = "calendar.eventLinked"
+    case reminderCreated = "reminder.created"
+    case geoEntered = "geo.entered"
+    case geoExited = "geo.exited"
+    case ruleFired = "rule.fired"
+    case ruleFailed = "rule.failed"
+    case inboxEnqueued = "inbox.enqueued"
+    case inboxClassified = "inbox.classified"
+    case inboxDismissed = "inbox.dismissed"
+}
+
+struct DomainEvent {
+    let kind: DomainEventKind
+    let payload: [String: Any]
+    let occurredAt: Date
+
+    init(kind: DomainEventKind, payload: [String: Any] = [:], occurredAt: Date = .now) {
+        self.kind = kind
+        self.payload = payload
+        self.occurredAt = occurredAt
+    }
+}
+
+final class EventDispatcher {
+    private let subject = PassthroughSubject<DomainEvent, Never>()
+
+    @discardableResult
+    func subscribe(_ receive: @escaping (DomainEvent) -> Void) -> AnyCancellable {
+        subject.sink(receiveValue: receive)
+    }
+
+    func post(_ event: DomainEvent) {
+        subject.send(event)
+    }
+
+    func post(kind: DomainEventKind, payload: [String: Any] = [:], occurredAt: Date = .now) {
+        post(DomainEvent(kind: kind, payload: payload, occurredAt: occurredAt))
+    }
+}

--- a/Core/Services/ServiceContainer.swift
+++ b/Core/Services/ServiceContainer.swift
@@ -4,8 +4,10 @@ struct ServiceContainer {
     let designSystem = DesignSystem()
     let testing = TestingUtilities()
     let persistence: PersistenceController
+    let events: EventDispatcher
 
-    init(persistence: PersistenceController) {
+    init(persistence: PersistenceController, eventDispatcher: EventDispatcher) {
         self.persistence = persistence
+        self.events = eventDispatcher
     }
 }

--- a/Keystone.xcodeproj/project.pbxproj
+++ b/Keystone.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
         A00100000000000000000013 /* WidgetsPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000013 /* WidgetsPlaceholder.swift */; };
         A00100000000000000000014 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000014 /* DesignSystem.swift */; };
         A00100000000000000000015 /* TestingUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000015 /* TestingUtilities.swift */; };
+        A0010000000000000000001A /* DomainEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0010001000000000000001A /* DomainEvent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
         A00100010000000000000013 /* WidgetsPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetsPlaceholder.swift; sourceTree = "<group>"; };
         A00100010000000000000014 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
         A00100010000000000000015 /* TestingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtilities.swift; sourceTree = "<group>"; };
+        A0010001000000000000001A /* DomainEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainEvent.swift; sourceTree = "<group>"; };
         A00100010000000000000016 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
         A00100010000000000000017 /* Keystone.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Keystone.entitlements; sourceTree = SOURCE_ROOT; };
         A00100010000000000000018 /* Keystone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Keystone.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -152,6 +154,7 @@
             isa = PBXGroup;
             children = (
                 A00100010000000000000004 /* AppEvent.swift */,
+                A0010001000000000000001A /* DomainEvent.swift */,
             );
             path = Events;
             sourceTree = "<group>";
@@ -374,6 +377,7 @@
                 A00100000000000000000015 /* TestingUtilities.swift in Sources */,
                 A00100000000000000000003 /* AppState.swift in Sources */,
                 A00100000000000000000004 /* AppEvent.swift in Sources */,
+                A0010000000000000000001A /* DomainEvent.swift in Sources */,
             );
         };
 /* End PBXSourcesBuildPhase section */


### PR DESCRIPTION
## Summary
- add domain event model types and dispatcher built on Combine
- expose the dispatcher through the service container and composition root

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf53fd26d48329b61e61a00493e60d