### PR TITLE
Implement rule engine DSL with evaluator and executor

### DIFF
--- a/Core/Rules/Engine/RuleDSL.swift
+++ b/Core/Rules/Engine/RuleDSL.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+public enum RuleTrigger: Equatable, Sendable {
+    case timeAt(String)
+    case geoEnter(String)
+    case event(String)
+    case inventoryBelowThreshold
+}
+
+public indirect enum RuleCondition: Equatable, Sendable {
+    case and([RuleCondition])
+    case or([RuleCondition])
+    case not(RuleCondition)
+    case eq(field: String, value: RuleValue)
+    case lt(field: String, value: Double)
+    case tagContains(String)
+    case listHasOpenItems
+}
+
+public enum RuleAction: Equatable, Sendable {
+    case notify(message: String)
+    case shoppingAddMissingFromLowStock
+    case transactionCreate(fromReceipt: Bool)
+    case habitTick(name: String, amount: Double)
+    case remindersCreate(title: String, dueISO8601: String)
+    case calendarBlock(title: String, startISO8601: String, durationMinutes: Int)
+}
+
+public enum RuleValue: Equatable, Sendable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+}
+
+public struct RuleDefinition: Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let trigger: RuleTrigger
+    public let conditions: [RuleCondition]
+    public let actions: [RuleAction]
+    public let enabled: Bool
+
+    public init(
+        id: UUID,
+        name: String,
+        trigger: RuleTrigger,
+        conditions: [RuleCondition],
+        actions: [RuleAction],
+        enabled: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.trigger = trigger
+        self.conditions = conditions
+        self.actions = actions
+        self.enabled = enabled
+    }
+}
+
+public struct RuleSnapshot: Equatable, Sendable {
+    public var fields: [String: RuleValue]
+    public var tags: Set<String>
+    public var listHasOpenItems: Bool
+
+    public init(
+        fields: [String: RuleValue] = [:],
+        tags: Set<String> = [],
+        listHasOpenItems: Bool = false
+    ) {
+        self.fields = fields
+        self.tags = tags
+        self.listHasOpenItems = listHasOpenItems
+    }
+
+    public func value(for field: String) -> RuleValue? {
+        fields[field]
+    }
+}
+
+public enum TriggerEvent: Equatable, Sendable {
+    case timeAt(String)
+    case geoEnter(String)
+    case event(String)
+    case inventoryBelowThreshold
+}
+
+extension RuleTrigger {
+    func matches(event: TriggerEvent) -> Bool {
+        switch (self, event) {
+        case let (.timeAt(expected), .timeAt(actual)):
+            return expected == actual
+        case let (.geoEnter(expected), .geoEnter(actual)):
+            return expected == actual
+        case let (.event(expected), .event(actual)):
+            return expected == actual
+        case (.inventoryBelowThreshold, .inventoryBelowThreshold):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+extension RuleValue {
+    var stringValue: String? {
+        if case let .string(value) = self { return value }
+        return nil
+    }
+
+    var numberValue: Double? {
+        if case let .number(value) = self { return value }
+        return nil
+    }
+
+    var boolValue: Bool? {
+        if case let .bool(value) = self { return value }
+        return nil
+    }
+}

--- a/Core/Rules/Engine/RuleEvaluator.swift
+++ b/Core/Rules/Engine/RuleEvaluator.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public struct RuleEvaluator: Sendable {
+    public init() {}
+
+    public func evaluate(rule: RuleDefinition, when event: TriggerEvent, snapshot: RuleSnapshot) -> [RuleAction] {
+        guard rule.enabled else { return [] }
+        guard rule.trigger.matches(event: event) else { return [] }
+
+        let conditionsSatisfied = rule.conditions.allSatisfy { condition in
+            evaluate(condition, with: snapshot)
+        }
+
+        return conditionsSatisfied ? rule.actions : []
+    }
+
+    private func evaluate(_ condition: RuleCondition, with snapshot: RuleSnapshot) -> Bool {
+        switch condition {
+        case let .and(conditions):
+            return conditions.allSatisfy { evaluate($0, with: snapshot) }
+        case let .or(conditions):
+            return conditions.contains { evaluate($0, with: snapshot) }
+        case let .not(condition):
+            return !evaluate(condition, with: snapshot)
+        case let .eq(field, value):
+            guard let fieldValue = snapshot.value(for: field) else { return false }
+            return fieldValue == value
+        case let .lt(field, value):
+            guard let fieldValue = snapshot.value(for: field)?.numberValue else { return false }
+            return fieldValue < value
+        case let .tagContains(tag):
+            return snapshot.tags.contains(tag)
+        case .listHasOpenItems:
+            return snapshot.listHasOpenItems
+        }
+    }
+}

--- a/Core/Rules/Engine/RuleExecutor.swift
+++ b/Core/Rules/Engine/RuleExecutor.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+public protocol NotificationService: Sendable {
+    func notify(message: String)
+}
+
+public protocol ShoppingService: Sendable {
+    func addMissingFromLowStock()
+}
+
+public protocol TransactionsService: Sendable {
+    func createTransaction(fromReceipt: Bool)
+}
+
+public protocol HabitsService: Sendable {
+    func tickHabit(name: String, amount: Double)
+}
+
+public protocol RemindersService: Sendable {
+    func createReminder(title: String, dueISO8601: String)
+}
+
+public protocol CalendarService: Sendable {
+    func blockTime(title: String, startISO8601: String, durationMinutes: Int)
+}
+
+public protocol RuleIdempotencyGuard: Sendable {
+    func shouldProceed(with ruleId: UUID) -> Bool
+}
+
+public struct RuleExecutionServices: Sendable {
+    public var notifications: NotificationService
+    public var shopping: ShoppingService
+    public var transactions: TransactionsService
+    public var habits: HabitsService
+    public var reminders: RemindersService
+    public var calendar: CalendarService
+
+    public init(
+        notifications: NotificationService,
+        shopping: ShoppingService,
+        transactions: TransactionsService,
+        habits: HabitsService,
+        reminders: RemindersService,
+        calendar: CalendarService
+    ) {
+        self.notifications = notifications
+        self.shopping = shopping
+        self.transactions = transactions
+        self.habits = habits
+        self.reminders = reminders
+        self.calendar = calendar
+    }
+}
+
+public struct RuleExecutor: Sendable {
+    private let services: RuleExecutionServices
+    private let idempotencyGuard: RuleIdempotencyGuard
+
+    public init(services: RuleExecutionServices, idempotencyGuard: RuleIdempotencyGuard) {
+        self.services = services
+        self.idempotencyGuard = idempotencyGuard
+    }
+
+    public func execute(rule: RuleDefinition, actions: [RuleAction]) {
+        guard !actions.isEmpty else { return }
+        guard idempotencyGuard.shouldProceed(with: rule.id) else { return }
+
+        for action in actions {
+            switch action {
+            case let .notify(message):
+                services.notifications.notify(message: message)
+            case .shoppingAddMissingFromLowStock:
+                services.shopping.addMissingFromLowStock()
+            case let .transactionCreate(fromReceipt):
+                services.transactions.createTransaction(fromReceipt: fromReceipt)
+            case let .habitTick(name, amount):
+                services.habits.tickHabit(name: name, amount: amount)
+            case let .remindersCreate(title, dueISO8601):
+                services.reminders.createReminder(title: title, dueISO8601: dueISO8601)
+            case let .calendarBlock(title, startISO8601, durationMinutes):
+                services.calendar.blockTime(title: title, startISO8601: startISO8601, durationMinutes: durationMinutes)
+            }
+        }
+    }
+}
+
+public final class InMemoryRuleIdempotencyGuard: RuleIdempotencyGuard {
+    private let ttl: TimeInterval
+    private let dateProvider: @Sendable () -> Date
+    private var expiryDates: [UUID: Date]
+    private let queue = DispatchQueue(label: "RuleIdempotencyGuard")
+
+    public init(ttl: TimeInterval = 30, dateProvider: @escaping @Sendable () -> Date = { Date() }) {
+        self.ttl = ttl
+        self.dateProvider = dateProvider
+        self.expiryDates = [:]
+    }
+
+    public func shouldProceed(with ruleId: UUID) -> Bool {
+        queue.sync {
+            let now = dateProvider()
+            expiryDates = expiryDates.filter { $0.value > now }
+            if let expiry = expiryDates[ruleId], expiry > now {
+                return false
+            }
+
+            expiryDates[ruleId] = now.addingTimeInterval(ttl)
+            return true
+        }
+    }
+}
+
+extension InMemoryRuleIdempotencyGuard: @unchecked Sendable {}

--- a/Core/Rules/Engine/RuleSpecCodec.swift
+++ b/Core/Rules/Engine/RuleSpecCodec.swift
@@ -1,0 +1,362 @@
+import Foundation
+import CoreFoundation
+
+public struct RuleSpecPayload: Sendable {
+    public var id: UUID
+    public var name: String
+    public var trigger: String
+    public var conditions: [String]
+    public var actions: [String]
+    public var enabled: Bool
+
+    public init(id: UUID, name: String, trigger: String, conditions: [String], actions: [String], enabled: Bool) {
+        self.id = id
+        self.name = name
+        self.trigger = trigger
+        self.conditions = conditions
+        self.actions = actions
+        self.enabled = enabled
+    }
+}
+
+public enum RuleSpecCodecError: Error, Equatable {
+    case invalidJSON
+    case invalidFunction(String)
+    case invalidArguments(String)
+    case unsupportedValue(String)
+}
+
+public struct RuleSpecCodec: Sendable {
+    public init() {}
+
+    public func decode(payload: RuleSpecPayload) throws -> RuleDefinition {
+        let trigger = try decodeTrigger(from: payload.trigger)
+        let conditions = try payload.conditions.map(decodeCondition)
+        let actions = try payload.actions.map(decodeAction)
+        return RuleDefinition(
+            id: payload.id,
+            name: payload.name,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions,
+            enabled: payload.enabled
+        )
+    }
+
+    public func encode(_ rule: RuleDefinition) throws -> RuleSpecPayload {
+        let trigger = try encode(trigger: rule.trigger)
+        let conditions = try rule.conditions.map(encode(condition:))
+        let actions = try rule.actions.map(encode(action:))
+        return RuleSpecPayload(
+            id: rule.id,
+            name: rule.name,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions,
+            enabled: rule.enabled
+        )
+    }
+
+    // MARK: - Trigger
+
+    private func decodeTrigger(from json: String) throws -> RuleTrigger {
+        let expression = try decodeExpression(from: json)
+        guard case let .function(name, arguments) = expression else {
+            throw RuleSpecCodecError.invalidFunction("Trigger must be a function")
+        }
+
+        switch name {
+        case "time.at":
+            let value = try arguments.expectSingleValue().requireString()
+            return .timeAt(value)
+        case "geo.enter":
+            let value = try arguments.expectSingleValue().requireString()
+            return .geoEnter(value)
+        case "event":
+            let value = try arguments.expectSingleValue().requireString()
+            return .event(value)
+        case "inventory.belowThreshold":
+            guard arguments.isEmpty else {
+                throw RuleSpecCodecError.invalidArguments("inventory.belowThreshold does not accept arguments")
+            }
+            return .inventoryBelowThreshold
+        default:
+            throw RuleSpecCodecError.invalidFunction("Unknown trigger: \(name)")
+        }
+    }
+
+    private func encode(trigger: RuleTrigger) throws -> String {
+        let expression: DSLExpression
+        switch trigger {
+        case let .timeAt(value):
+            expression = .function(name: "time.at", arguments: [.value(.string(value))])
+        case let .geoEnter(value):
+            expression = .function(name: "geo.enter", arguments: [.value(.string(value))])
+        case let .event(value):
+            expression = .function(name: "event", arguments: [.value(.string(value))])
+        case .inventoryBelowThreshold:
+            expression = .function(name: "inventory.belowThreshold", arguments: [])
+        }
+        return try encode(expression: expression)
+    }
+
+    // MARK: - Conditions
+
+    private func decodeCondition(from json: String) throws -> RuleCondition {
+        let expression = try decodeExpression(from: json)
+        return try decodeCondition(from: expression)
+    }
+
+    private func decodeCondition(from expression: DSLExpression) throws -> RuleCondition {
+        guard case let .function(name, arguments) = expression else {
+            throw RuleSpecCodecError.invalidFunction("Condition must be a function")
+        }
+
+        switch name {
+        case "and":
+            let conditions = try arguments.map { try decodeCondition(from: $0) }
+            return .and(conditions)
+        case "or":
+            let conditions = try arguments.map { try decodeCondition(from: $0) }
+            return .or(conditions)
+        case "not":
+            let condition = try arguments.expectSingleFunction()
+            return .not(try decodeCondition(from: condition))
+        case "eq":
+            guard arguments.count == 2 else {
+                throw RuleSpecCodecError.invalidArguments("eq requires 2 arguments")
+            }
+            let field = try arguments[0].requireString()
+            let value = try arguments[1].requireRuleValue()
+            return .eq(field: field, value: value)
+        case "lt":
+            guard arguments.count == 2 else {
+                throw RuleSpecCodecError.invalidArguments("lt requires 2 arguments")
+            }
+            let field = try arguments[0].requireString()
+            guard case let .number(number) = try arguments[1].requireRuleValue() else {
+                throw RuleSpecCodecError.invalidArguments("lt requires a numeric value")
+            }
+            return .lt(field: field, value: number)
+        case "tagContains":
+            let tag = try arguments.expectSingleValue().requireString()
+            return .tagContains(tag)
+        case "listHasOpenItems":
+            guard arguments.isEmpty else {
+                throw RuleSpecCodecError.invalidArguments("listHasOpenItems does not accept arguments")
+            }
+            return .listHasOpenItems
+        default:
+            throw RuleSpecCodecError.invalidFunction("Unknown condition: \(name)")
+        }
+    }
+
+    private func encode(condition: RuleCondition) throws -> String {
+        let expression = try encodeConditionExpression(condition)
+        return try encode(expression: expression)
+    }
+
+    private func encodeConditionExpression(_ condition: RuleCondition) throws -> DSLExpression {
+        switch condition {
+        case let .and(conditions):
+            return .function(name: "and", arguments: try conditions.map { try encodeConditionExpression($0) })
+        case let .or(conditions):
+            return .function(name: "or", arguments: try conditions.map { try encodeConditionExpression($0) })
+        case let .not(condition):
+            return .function(name: "not", arguments: [try encodeConditionExpression(condition)])
+        case let .eq(field, value):
+            return .function(name: "eq", arguments: [.value(.string(field)), .value(value)])
+        case let .lt(field, value):
+            return .function(name: "lt", arguments: [.value(.string(field)), .value(.number(value))])
+        case let .tagContains(tag):
+            return .function(name: "tagContains", arguments: [.value(.string(tag))])
+        case .listHasOpenItems:
+            return .function(name: "listHasOpenItems", arguments: [])
+        }
+    }
+
+    // MARK: - Actions
+
+    private func decodeAction(from json: String) throws -> RuleAction {
+        let expression = try decodeExpression(from: json)
+        guard case let .function(name, arguments) = expression else {
+            throw RuleSpecCodecError.invalidFunction("Action must be a function")
+        }
+
+        switch name {
+        case "notify":
+            let message = try arguments.expectSingleValue().requireString()
+            return .notify(message: message)
+        case "shopping.addMissingFromLowStock":
+            guard arguments.isEmpty else {
+                throw RuleSpecCodecError.invalidArguments("shopping.addMissingFromLowStock does not accept arguments")
+            }
+            return .shoppingAddMissingFromLowStock
+        case "transaction.create":
+            guard arguments.count == 1 else {
+                throw RuleSpecCodecError.invalidArguments("transaction.create requires 1 argument")
+            }
+            guard case let .bool(fromReceipt) = try arguments[0].requireRuleValue() else {
+                throw RuleSpecCodecError.invalidArguments("transaction.create expects a boolean")
+            }
+            return .transactionCreate(fromReceipt: fromReceipt)
+        case "habit.tick":
+            guard arguments.count == 2 else {
+                throw RuleSpecCodecError.invalidArguments("habit.tick requires 2 arguments")
+            }
+            let name = try arguments[0].requireString()
+            guard case let .number(amount) = try arguments[1].requireRuleValue() else {
+                throw RuleSpecCodecError.invalidArguments("habit.tick amount must be numeric")
+            }
+            return .habitTick(name: name, amount: amount)
+        case "reminders.create":
+            guard arguments.count == 2 else {
+                throw RuleSpecCodecError.invalidArguments("reminders.create requires 2 arguments")
+            }
+            let title = try arguments[0].requireString()
+            let due = try arguments[1].requireString()
+            return .remindersCreate(title: title, dueISO8601: due)
+        case "calendar.block":
+            guard arguments.count == 3 else {
+                throw RuleSpecCodecError.invalidArguments("calendar.block requires 3 arguments")
+            }
+            let title = try arguments[0].requireString()
+            let start = try arguments[1].requireString()
+            guard case let .number(duration) = try arguments[2].requireRuleValue() else {
+                throw RuleSpecCodecError.invalidArguments("calendar.block duration must be numeric")
+            }
+            return .calendarBlock(title: title, startISO8601: start, durationMinutes: Int(duration))
+        default:
+            throw RuleSpecCodecError.invalidFunction("Unknown action: \(name)")
+        }
+    }
+
+    private func encode(action: RuleAction) throws -> String {
+        let expression: DSLExpression
+        switch action {
+        case let .notify(message):
+            expression = .function(name: "notify", arguments: [.value(.string(message))])
+        case .shoppingAddMissingFromLowStock:
+            expression = .function(name: "shopping.addMissingFromLowStock", arguments: [])
+        case let .transactionCreate(fromReceipt):
+            expression = .function(name: "transaction.create", arguments: [.value(.bool(fromReceipt))])
+        case let .habitTick(name, amount):
+            expression = .function(name: "habit.tick", arguments: [.value(.string(name)), .value(.number(amount))])
+        case let .remindersCreate(title, dueISO8601):
+            expression = .function(name: "reminders.create", arguments: [.value(.string(title)), .value(.string(dueISO8601))])
+        case let .calendarBlock(title, startISO8601, durationMinutes):
+            expression = .function(
+                name: "calendar.block",
+                arguments: [
+                    .value(.string(title)),
+                    .value(.string(startISO8601)),
+                    .value(.number(Double(durationMinutes)))
+                ]
+            )
+        }
+        return try encode(expression: expression)
+    }
+
+    // MARK: - Expression Helpers
+
+    private func decodeExpression(from json: String) throws -> DSLExpression {
+        guard let data = json.data(using: .utf8) else { throw RuleSpecCodecError.invalidJSON }
+        let raw = try JSONSerialization.jsonObject(with: data)
+        return try DSLExpression.from(raw: raw)
+    }
+
+    private func encode(expression: DSLExpression) throws -> String {
+        let raw = try expression.toRaw()
+        guard JSONSerialization.isValidJSONObject(raw) else {
+            throw RuleSpecCodecError.invalidJSON
+        }
+        let data = try JSONSerialization.data(withJSONObject: raw, options: [.sortedKeys])
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw RuleSpecCodecError.invalidJSON
+        }
+        return string
+    }
+}
+
+// MARK: - DSLExpression
+
+private enum DSLExpression: Sendable {
+    case function(name: String, arguments: [DSLExpression])
+    case value(RuleValue)
+
+    static func from(raw: Any) throws -> DSLExpression {
+        if let array = raw as? [Any] {
+            guard let first = array.first as? String else {
+                throw RuleSpecCodecError.invalidFunction("Function name missing")
+            }
+            let arguments = try array.dropFirst().map { try DSLExpression.from(raw: $0) }
+            return .function(name: first, arguments: arguments)
+        }
+
+        if let string = raw as? String {
+            return .value(.string(string))
+        }
+        if let number = raw as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .value(.bool(number.boolValue))
+            } else {
+                return .value(.number(number.doubleValue))
+            }
+        }
+
+        throw RuleSpecCodecError.unsupportedValue("Unsupported literal: \(raw)")
+    }
+
+    func toRaw() throws -> Any {
+        switch self {
+        case let .function(name, arguments):
+            var array: [Any] = [name]
+            for argument in arguments {
+                array.append(try argument.toRaw())
+            }
+            return array
+        case let .value(value):
+            switch value {
+            case let .string(string):
+                return string
+            case let .number(number):
+                return number
+            case let .bool(bool):
+                return bool
+            }
+        }
+    }
+}
+
+private extension Array where Element == DSLExpression {
+    func expectSingleValue() throws -> DSLExpression {
+        guard count == 1 else {
+            throw RuleSpecCodecError.invalidArguments("Expected a single argument")
+        }
+        return self[0]
+    }
+
+    func expectSingleFunction() throws -> DSLExpression {
+        let expression = try expectSingleValue()
+        guard case .function = expression else {
+            throw RuleSpecCodecError.invalidArguments("Expected a condition function")
+        }
+        return expression
+    }
+}
+
+private extension DSLExpression {
+    func requireString() throws -> String {
+        guard case let .value(value) = self, case let .string(string) = value else {
+            throw RuleSpecCodecError.invalidArguments("Expected string literal")
+        }
+        return string
+    }
+
+    func requireRuleValue() throws -> RuleValue {
+        guard case let .value(value) = self else {
+            throw RuleSpecCodecError.invalidArguments("Expected literal value")
+        }
+        return value
+    }
+}

--- a/Core/Rules/RuleSpecBridge.swift
+++ b/Core/Rules/RuleSpecBridge.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension RuleSpec {
+    func toRuleDefinition(codec: RuleSpecCodec = RuleSpecCodec()) throws -> RuleDefinition {
+        let payload = RuleSpecPayload(
+            id: id,
+            name: name,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions,
+            enabled: enabled
+        )
+        return try codec.decode(payload: payload)
+    }
+
+    static func from(rule: RuleDefinition, codec: RuleSpecCodec = RuleSpecCodec()) throws -> RuleSpec {
+        let payload = try codec.encode(rule)
+        return try RuleSpec(
+            id: payload.id,
+            name: payload.name,
+            trigger: payload.trigger,
+            conditions: payload.conditions,
+            actions: payload.actions,
+            enabled: payload.enabled
+        )
+    }
+}

--- a/Core/Rules/Tests/RuleEngineTests.swift
+++ b/Core/Rules/Tests/RuleEngineTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import RuleEngine
+
+final class RuleEngineTests: XCTestCase {
+    func testInventoryBelowThresholdAddsMissingItems() throws {
+        let rule = RuleDefinition(
+            id: UUID(),
+            name: "Restock",
+            trigger: .inventoryBelowThreshold,
+            conditions: [],
+            actions: [.shoppingAddMissingFromLowStock],
+            enabled: true
+        )
+
+        let evaluator = RuleEvaluator()
+        let actions = evaluator.evaluate(rule: rule, when: .inventoryBelowThreshold, snapshot: RuleSnapshot())
+        XCTAssertEqual(actions, [.shoppingAddMissingFromLowStock])
+
+        let services = TestServices()
+        let executor = RuleExecutor(services: services.container, idempotencyGuard: services.idempotency)
+        executor.execute(rule: rule, actions: actions)
+
+        XCTAssertEqual(services.shopping.addMissingFromLowStockCallCount, 1)
+    }
+
+    func testReceiptScannedCreatesTransaction() throws {
+        let rule = RuleDefinition(
+            id: UUID(),
+            name: "Log receipt",
+            trigger: .event("receipt.scanned"),
+            conditions: [],
+            actions: [.transactionCreate(fromReceipt: true)],
+            enabled: true
+        )
+
+        let evaluator = RuleEvaluator()
+        let actions = evaluator.evaluate(rule: rule, when: .event("receipt.scanned"), snapshot: RuleSnapshot())
+        XCTAssertEqual(actions, [.transactionCreate(fromReceipt: true)])
+
+        let services = TestServices()
+        let executor = RuleExecutor(services: services.container, idempotencyGuard: services.idempotency)
+        executor.execute(rule: rule, actions: actions)
+
+        XCTAssertEqual(services.transactions.createTransactionCalls, [.init(fromReceipt: true)])
+    }
+}
+
+// MARK: - Test Helpers
+
+private final class TestServices {
+    let notifications = MockNotificationsService()
+    let shopping = MockShoppingService()
+    let transactions = MockTransactionsService()
+    let habits = MockHabitsService()
+    let reminders = MockRemindersService()
+    let calendar = MockCalendarService()
+    let idempotency = AlwaysAllowGuard()
+
+    var container: RuleExecutionServices {
+        RuleExecutionServices(
+            notifications: notifications,
+            shopping: shopping,
+            transactions: transactions,
+            habits: habits,
+            reminders: reminders,
+            calendar: calendar
+        )
+    }
+}
+
+private final class MockNotificationsService: NotificationService {
+    func notify(message: String) {}
+}
+
+private final class MockShoppingService: ShoppingService {
+    private(set) var addMissingFromLowStockCallCount = 0
+    func addMissingFromLowStock() {
+        addMissingFromLowStockCallCount += 1
+    }
+}
+
+extension MockShoppingService: @unchecked Sendable {}
+
+private struct TransactionCall: Equatable {
+    let fromReceipt: Bool
+}
+
+private final class MockTransactionsService: TransactionsService {
+    private(set) var createTransactionCalls: [TransactionCall] = []
+    func createTransaction(fromReceipt: Bool) {
+        createTransactionCalls.append(TransactionCall(fromReceipt: fromReceipt))
+    }
+}
+
+extension MockTransactionsService: @unchecked Sendable {}
+
+private final class MockHabitsService: HabitsService {
+    func tickHabit(name: String, amount: Double) {}
+}
+
+private final class MockRemindersService: RemindersService {
+    func createReminder(title: String, dueISO8601: String) {}
+}
+
+private final class MockCalendarService: CalendarService {
+    func blockTime(title: String, startISO8601: String, durationMinutes: Int) {}
+}
+
+private final class AlwaysAllowGuard: RuleIdempotencyGuard {
+    func shouldProceed(with ruleId: UUID) -> Bool { true }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "KeystoneRules",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "RuleEngine", targets: ["RuleEngine"])
+    ],
+    targets: [
+        .target(
+            name: "RuleEngine",
+            path: "Core/Rules/Engine"
+        ),
+        .testTarget(
+            name: "RuleEngineTests",
+            dependencies: ["RuleEngine"],
+            path: "Core/Rules/Tests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- introduce a JSON-based DSL for triggers, conditions, actions, and actions encoding/decoding
- add a pure-function evaluator plus executor with service protocols and in-memory idempotency guard
- bridge persistence RuleSpec records into the engine and add Swift Package + unit tests for critical flows

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf54f140108329aa8286a556cc34b5