### PR TITLE
Add core services for OCR, barcode scanning, geofencing, and CSV import

### DIFF
--- a/Core/Services/BarcodeService.swift
+++ b/Core/Services/BarcodeService.swift
@@ -1,0 +1,189 @@
+import AVFoundation
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+typealias UIViewController = NSViewController
+#endif
+
+protocol BarcodeScannerDelegate: AnyObject {
+    func barcodeScanner(_ scanner: UIViewController, didScan code: String)
+    func barcodeScannerDidCancel(_ scanner: UIViewController)
+}
+
+struct BarcodeProduct: Codable, Equatable {
+    let code: String
+    let name: String
+    let unit: String?
+}
+
+protocol BarcodeServicing: AnyObject {
+    func makeScanner(delegate: BarcodeScannerDelegate) -> UIViewController
+    func lookupProduct(for code: String) async -> BarcodeProduct?
+    func overrideProduct(_ product: BarcodeProduct) async
+}
+
+private actor BarcodeCatalogStore {
+    private var catalog: [String: BarcodeProduct]
+    private var overrides: [String: BarcodeProduct]
+    private let userDefaults: UserDefaults
+    private let overridesKey = "barcode_service_overrides"
+
+    init(bundle: Bundle, userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+        if let overridesData = userDefaults.data(forKey: overridesKey),
+           let stored = try? JSONDecoder().decode([String: BarcodeProduct].self, from: overridesData) {
+            self.overrides = stored
+        } else {
+            self.overrides = [:]
+        }
+
+        if let url = bundle.url(forResource: "ean_catalog", withExtension: "json"),
+           let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode([String: BarcodeProduct].self, from: data) {
+            self.catalog = decoded
+        } else {
+            self.catalog = [:]
+        }
+    }
+
+    func lookup(code: String) -> BarcodeProduct? {
+        if let override = overrides[code] {
+            return override
+        }
+        return catalog[code]
+    }
+
+    func storeOverride(_ product: BarcodeProduct) {
+        overrides[product.code] = product
+        if let data = try? JSONEncoder().encode(overrides) {
+            userDefaults.set(data, forKey: overridesKey)
+        }
+    }
+}
+
+final class BarcodeService: NSObject, BarcodeServicing {
+    private let store: BarcodeCatalogStore
+
+    init(bundle: Bundle = .main, userDefaults: UserDefaults = .standard) {
+        self.store = BarcodeCatalogStore(bundle: bundle, userDefaults: userDefaults)
+    }
+
+    func makeScanner(delegate: BarcodeScannerDelegate) -> UIViewController {
+        BarcodeScannerViewController(delegate: delegate)
+    }
+
+    func lookupProduct(for code: String) async -> BarcodeProduct? {
+        let normalized = normalize(code: code)
+        return await store.lookup(code: normalized)
+    }
+
+    func overrideProduct(_ product: BarcodeProduct) async {
+        let normalized = normalize(code: product.code)
+        let normalizedProduct = BarcodeProduct(code: normalized, name: product.name, unit: product.unit)
+        await store.storeOverride(normalizedProduct)
+    }
+
+    private func normalize(code: String) -> String {
+        code.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+#if canImport(UIKit)
+private final class BarcodeScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    private let session = AVCaptureSession()
+    private let previewLayer = AVCaptureVideoPreviewLayer()
+    private weak var delegate: BarcodeScannerDelegate?
+    private var hasDeliveredResult = false
+
+    init(delegate: BarcodeScannerDelegate) {
+        self.delegate = delegate
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureSession()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer.frame = view.bounds
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        hasDeliveredResult = false
+        if !session.isRunning {
+            session.startRunning()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if session.isRunning {
+            session.stopRunning()
+        }
+    }
+
+    private func configureSession() {
+        view.backgroundColor = .black
+
+        guard let videoDevice = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: videoDevice) else {
+            return
+        }
+
+        if session.canAddInput(input) {
+            session.addInput(input)
+        }
+
+        let metadataOutput = AVCaptureMetadataOutput()
+        if session.canAddOutput(metadataOutput) {
+            session.addOutput(metadataOutput)
+            metadataOutput.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+            metadataOutput.metadataObjectTypes = [.ean8, .ean13, .upce]
+        }
+
+        previewLayer.session = session
+        previewLayer.videoGravity = .resizeAspectFill
+        view.layer.addSublayer(previewLayer)
+    }
+
+    func metadataOutput(
+        _ output: AVCaptureMetadataOutput,
+        didOutput metadataObjects: [AVMetadataObject],
+        from connection: AVCaptureConnection
+    ) {
+        guard !hasDeliveredResult,
+              let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              let stringValue = object.stringValue else { return }
+
+        hasDeliveredResult = true
+        session.stopRunning()
+        delegate?.barcodeScanner(self, didScan: stringValue)
+    }
+
+    @objc
+    private func cancel() {
+        delegate?.barcodeScannerDidCancel(self)
+    }
+}
+#else
+private final class BarcodeScannerViewController: UIViewController {
+    init(delegate: BarcodeScannerDelegate) {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+#endif

--- a/Core/Services/CSVImportService.swift
+++ b/Core/Services/CSVImportService.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+struct CSVTransactionRecord: Equatable {
+    let date: Date
+    let description: String
+    let amount: Decimal
+}
+
+struct CSVInventoryRecord: Equatable {
+    let name: String
+    let quantity: Decimal
+    let unit: String?
+    let barcode: String?
+}
+
+enum CSVImportError: LocalizedError {
+    case invalidHeader(expected: [String], actual: [String])
+    case invalidDecimal(String)
+    case invalidDate(String)
+    case missingField(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidHeader(expected, actual):
+            return "Invalid CSV header. Expected: \(expected.joined(separator: ", ")), actual: \(actual.joined(separator: ", "))."
+        case let .invalidDecimal(value):
+            return "Unable to parse decimal value from \(value)."
+        case let .invalidDate(value):
+            return "Unable to parse date value from \(value)."
+        case let .missingField(field):
+            return "The field \(field) is required."
+        }
+    }
+}
+
+protocol CSVImportServicing {
+    func importTransactions(
+        from url: URL,
+        dateFormatters: [DateFormatter]
+    ) async throws -> [CSVTransactionRecord]
+
+    func importInventory(from url: URL) async throws -> [CSVInventoryRecord]
+}
+
+final class CSVImportService: CSVImportServicing {
+    private let parser: CSVParser
+
+    init(parser: CSVParser = CSVParser()) {
+        self.parser = parser
+    }
+
+    func importTransactions(
+        from url: URL,
+        dateFormatters: [DateFormatter]
+    ) async throws -> [CSVTransactionRecord] {
+        let rows = try parser.parse(url: url)
+        guard let header = rows.first else {
+            return []
+        }
+
+        let expectedHeader = ["date", "description", "amount"]
+        guard header.caseInsensitiveElementsEqual(expectedHeader) else {
+            throw CSVImportError.invalidHeader(expected: expectedHeader, actual: header)
+        }
+
+        let normalizedHeader = header.map { $0.lowercased() }
+
+        return try rows.dropFirst().map { row in
+            let mapped = Dictionary(uniqueKeysWithValues: zip(normalizedHeader, row))
+
+            guard let dateString = mapped["date"], !dateString.isEmpty else {
+                throw CSVImportError.missingField("date")
+            }
+
+            guard let description = mapped["description"], !description.isEmpty else {
+                throw CSVImportError.missingField("description")
+            }
+
+            guard let amountString = mapped["amount"], !amountString.isEmpty else {
+                throw CSVImportError.missingField("amount")
+            }
+
+            guard let amount = DecimalFormatter.decimal(from: amountString) else {
+                throw CSVImportError.invalidDecimal(amountString)
+            }
+
+            guard let date = dateFormatters.firstNonNil({ $0.date(from: dateString) }) else {
+                throw CSVImportError.invalidDate(dateString)
+            }
+
+            return CSVTransactionRecord(date: date, description: description, amount: amount)
+        }
+    }
+
+    func importInventory(from url: URL) async throws -> [CSVInventoryRecord] {
+        let rows = try parser.parse(url: url)
+        guard let header = rows.first else {
+            return []
+        }
+
+        let expectedHeader = ["name", "quantity", "unit", "barcode"]
+        guard header.caseInsensitiveElementsEqual(expectedHeader) else {
+            throw CSVImportError.invalidHeader(expected: expectedHeader, actual: header)
+        }
+
+        let normalizedHeader = header.map { $0.lowercased() }
+
+        return try rows.dropFirst().map { row in
+            let mapped = Dictionary(uniqueKeysWithValues: zip(normalizedHeader, row))
+
+            guard let name = mapped["name"], !name.isEmpty else {
+                throw CSVImportError.missingField("name")
+            }
+
+            guard let quantityString = mapped["quantity"], !quantityString.isEmpty else {
+                throw CSVImportError.missingField("quantity")
+            }
+
+            guard let quantity = DecimalFormatter.decimal(from: quantityString) else {
+                throw CSVImportError.invalidDecimal(quantityString)
+            }
+
+            let unit = mapped["unit"].flatMap { $0.isEmpty ? nil : $0 }
+            let barcode = mapped["barcode"].flatMap { $0.isEmpty ? nil : $0 }
+
+            return CSVInventoryRecord(name: name, quantity: quantity, unit: unit, barcode: barcode)
+        }
+    }
+}
+
+final class CSVParser {
+    private let delimiter: Character
+
+    init(delimiter: Character = ",") {
+        self.delimiter = delimiter
+    }
+
+    func parse(url: URL) throws -> [[String]] {
+        let data = try Data(contentsOf: url)
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return parse(string: content)
+    }
+
+    func parse(string: String) -> [[String]] {
+        var rows: [[String]] = []
+        var currentRow: [String] = []
+        var currentField = ""
+        var isInsideQuotes = false
+        var previousCharacter: Character?
+        let characters = Array(string)
+        var index = 0
+
+        while index < characters.count {
+            let character = characters[index]
+
+            if character == "\"" {
+                if isInsideQuotes,
+                   index + 1 < characters.count,
+                   characters[index + 1] == "\"" {
+                    currentField.append("\"")
+                    index += 2
+                    previousCharacter = "\""
+                    continue
+                } else {
+                    isInsideQuotes.toggle()
+                    index += 1
+                    previousCharacter = character
+                    continue
+                }
+            }
+
+            if character == delimiter && !isInsideQuotes {
+                currentRow.append(currentField)
+                currentField = ""
+                index += 1
+                previousCharacter = character
+                continue
+            }
+
+            if character.isNewline && !isInsideQuotes {
+                if !(previousCharacter == "\r" && character == "\n") {
+                    currentRow.append(currentField)
+                    rows.append(currentRow)
+                    currentRow = []
+                }
+                currentField = ""
+                index += 1
+                previousCharacter = character
+                continue
+            }
+
+            currentField.append(character)
+            index += 1
+            previousCharacter = character
+        }
+
+        if !currentField.isEmpty || !currentRow.isEmpty {
+            currentRow.append(currentField)
+            rows.append(currentRow)
+        }
+
+        return rows
+    }
+}
+
+private enum DecimalFormatter {
+    static func decimal(from string: String) -> Decimal? {
+        let allowedCharacters = CharacterSet(charactersIn: "0123456789.,-")
+        let filteredScalars = string.unicodeScalars.filter { allowedCharacters.contains($0) }
+        var sanitized = String(String.UnicodeScalarView(filteredScalars)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitized.isEmpty else { return nil }
+
+        if sanitized.contains(",") && !sanitized.contains(".") {
+            sanitized = sanitized.replacingOccurrences(of: ".", with: "")
+            sanitized = sanitized.replacingOccurrences(of: ",", with: ".")
+        } else {
+            sanitized = sanitized.replacingOccurrences(of: ",", with: "")
+        }
+
+        return Decimal(string: sanitized)
+    }
+}
+
+private extension Array where Element == String {
+    func caseInsensitiveElementsEqual(_ other: [String]) -> Bool {
+        guard count == other.count else { return false }
+        for (lhs, rhs) in zip(self, other) {
+            if lhs.lowercased() != rhs.lowercased() {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+private extension Array {
+    func firstNonNil<T>(_ transform: (Element) -> T?) -> T? {
+        for element in self {
+            if let value = transform(element) {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Core/Services/LocationService.swift
+++ b/Core/Services/LocationService.swift
@@ -1,0 +1,167 @@
+import Combine
+import CoreLocation
+import Foundation
+
+enum LocationServiceError: LocalizedError {
+    case monitoringUnavailable
+    case authorizationDenied
+    case invalidCoordinate
+
+    var errorDescription: String? {
+        switch self {
+        case .monitoringUnavailable:
+            return "Geofencing is not supported on this device."
+        case .authorizationDenied:
+            return "Location permissions are required to register merchant geofences."
+        case .invalidCoordinate:
+            return "The coordinate provided for the merchant is invalid."
+        }
+    }
+}
+
+@MainActor
+protocol LocationServicing: AnyObject {
+    var didEnterMerchantRegion: AnyPublisher<UUID, Never> { get }
+    var didExitMerchantRegion: AnyPublisher<UUID, Never> { get }
+
+    func requestAuthorization() async -> CLAuthorizationStatus
+    func registerGeofence(
+        merchantId: UUID,
+        coordinate: CLLocationCoordinate2D,
+        radius: CLLocationDistance
+    ) async throws
+    func removeGeofence(for merchantId: UUID)
+    func removeAllGeofences()
+}
+
+@MainActor
+final class LocationService: NSObject, LocationServicing {
+    private let locationManager: CLLocationManager
+    private let enterSubject = PassthroughSubject<UUID, Never>()
+    private let exitSubject = PassthroughSubject<UUID, Never>()
+    private var monitoredRegions: [UUID: CLCircularRegion] = [:]
+    private var authorizationContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
+
+    var didEnterMerchantRegion: AnyPublisher<UUID, Never> {
+        enterSubject.eraseToAnyPublisher()
+    }
+
+    var didExitMerchantRegion: AnyPublisher<UUID, Never> {
+        exitSubject.eraseToAnyPublisher()
+    }
+
+    override init() {
+        locationManager = CLLocationManager()
+        super.init()
+        locationManager.delegate = self
+        locationManager.pausesLocationUpdatesAutomatically = false
+    }
+
+    func requestAuthorization() async -> CLAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            let status = locationManager.authorizationStatus
+            switch status {
+            case .notDetermined:
+                authorizationContinuation?.resume(returning: status)
+                authorizationContinuation = continuation
+                locationManager.requestAlwaysAuthorization()
+            default:
+                continuation.resume(returning: status)
+            }
+        }
+    }
+
+    func registerGeofence(
+        merchantId: UUID,
+        coordinate: CLLocationCoordinate2D,
+        radius: CLLocationDistance
+    ) async throws {
+        guard CLLocationCoordinate2DIsValid(coordinate) else {
+            throw LocationServiceError.invalidCoordinate
+        }
+
+        guard CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self) else {
+            throw LocationServiceError.monitoringUnavailable
+        }
+
+        let status = locationManager.authorizationStatus
+        guard status == .authorizedAlways || status == .authorizedWhenInUse else {
+            throw LocationServiceError.authorizationDenied
+        }
+
+        let maximumRadius = locationManager.maximumRegionMonitoringDistance
+        let resolvedRadius: CLLocationDistance
+        if maximumRadius > 0 {
+            resolvedRadius = min(radius, maximumRadius)
+        } else {
+            resolvedRadius = radius
+        }
+
+        let region = CLCircularRegion(
+            center: coordinate,
+            radius: resolvedRadius,
+            identifier: merchantId.uuidString
+        )
+        region.notifyOnEntry = true
+        region.notifyOnExit = true
+
+        monitoredRegions[merchantId] = region
+        locationManager.startMonitoring(for: region)
+    }
+
+    func removeGeofence(for merchantId: UUID) {
+        guard let region = monitoredRegions.removeValue(forKey: merchantId) else { return }
+        locationManager.stopMonitoring(for: region)
+    }
+
+    func removeAllGeofences() {
+        for region in monitoredRegions.values {
+            locationManager.stopMonitoring(for: region)
+        }
+        monitoredRegions.removeAll()
+    }
+}
+
+extension LocationService: CLLocationManagerDelegate {
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        if let continuation = authorizationContinuation {
+            continuation.resume(returning: manager.authorizationStatus)
+            authorizationContinuation = nil
+        }
+    }
+
+    func locationManager(
+        _ manager: CLLocationManager,
+        didChangeAuthorization status: CLAuthorizationStatus
+    ) {
+        if let continuation = authorizationContinuation {
+            continuation.resume(returning: status)
+            authorizationContinuation = nil
+        }
+    }
+
+    func locationManager(
+        _ manager: CLLocationManager,
+        didEnterRegion region: CLRegion
+    ) {
+        guard let identifier = UUID(uuidString: region.identifier) else { return }
+        enterSubject.send(identifier)
+    }
+
+    func locationManager(
+        _ manager: CLLocationManager,
+        didExitRegion region: CLRegion
+    ) {
+        guard let identifier = UUID(uuidString: region.identifier) else { return }
+        exitSubject.send(identifier)
+    }
+
+    func locationManager(
+        _ manager: CLLocationManager,
+        monitoringDidFailFor region: CLRegion?,
+        withError error: Error
+    ) {
+        guard let region, let identifier = UUID(uuidString: region.identifier) else { return }
+        monitoredRegions.removeValue(forKey: identifier)
+    }
+}

--- a/Core/Services/ServiceContainer.swift
+++ b/Core/Services/ServiceContainer.swift
@@ -5,9 +5,24 @@ struct ServiceContainer {
     let testing = TestingUtilities()
     let persistence: PersistenceController
     let events: EventDispatcher
+    let vision: any VisionOCRServicing
+    let barcode: any BarcodeServicing
+    let location: any LocationServicing
+    let csvImporter: any CSVImportServicing
 
-    init(persistence: PersistenceController, eventDispatcher: EventDispatcher) {
+    init(
+        persistence: PersistenceController,
+        eventDispatcher: EventDispatcher,
+        vision: any VisionOCRServicing = VisionOCRService(),
+        barcode: any BarcodeServicing = BarcodeService(),
+        location: any LocationServicing = LocationService(),
+        csvImporter: any CSVImportServicing = CSVImportService()
+    ) {
         self.persistence = persistence
         self.events = eventDispatcher
+        self.vision = vision
+        self.barcode = barcode
+        self.location = location
+        self.csvImporter = csvImporter
     }
 }

--- a/Core/Services/VisionOCRService.swift
+++ b/Core/Services/VisionOCRService.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Vision
+#if canImport(UIKit)
+import UIKit
+#endif
+
+struct VisionOCRConfidence<Value> {
+    let value: Value?
+    let confidence: Float
+}
+
+struct VisionOCRLineItem {
+    let name: VisionOCRConfidence<String>
+    let quantity: VisionOCRConfidence<Decimal>
+    let price: VisionOCRConfidence<Decimal>
+}
+
+struct VisionOCRResult {
+    let merchant: VisionOCRConfidence<String>
+    let date: VisionOCRConfidence<Date>
+    let total: VisionOCRConfidence<Decimal>
+    let lineItems: [VisionOCRLineItem]
+}
+
+protocol VisionOCRServicing {
+    func scan(image: PlatformImage) async throws -> VisionOCRResult
+    func scan(at url: URL) async throws -> VisionOCRResult
+}
+
+#if canImport(UIKit)
+typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformImage = NSImage
+#else
+typealias PlatformImage = Any
+#endif
+
+enum VisionOCRError: LocalizedError {
+    case invalidImage
+    case recognitionFailed(Error)
+    case unsupportedPlatform
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidImage:
+            return "The provided image could not be processed for OCR."
+        case let .recognitionFailed(error):
+            return "Text recognition failed with error: \(error.localizedDescription)"
+        case .unsupportedPlatform:
+            return "OCR is not supported on the current platform."
+        }
+    }
+}
+
+final class VisionOCRService: VisionOCRServicing {
+    private let recognitionLanguages: [String]
+    private let totalKeywords: [String]
+    private let dateParsers: [DateFormatter]
+
+    init(
+        recognitionLanguages: [String] = Locale.preferredLanguages,
+        totalKeywords: [String] = ["total", "amount", "balance"],
+        dateFormats: [String] = [
+            "yyyy-MM-dd",
+            "MM/dd/yyyy",
+            "dd/MM/yyyy",
+            "MMM d, yyyy",
+            "MMMM d, yyyy"
+        ]
+    ) {
+        self.recognitionLanguages = recognitionLanguages
+        self.totalKeywords = totalKeywords
+        self.dateParsers = dateFormats.map { format in
+            let formatter = DateFormatter()
+            formatter.dateFormat = format
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            return formatter
+        }
+    }
+
+    func scan(image: PlatformImage) async throws -> VisionOCRResult {
+        #if canImport(UIKit)
+        guard let cgImage = image.cgImage else {
+            throw VisionOCRError.invalidImage
+        }
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        return try await performScan(handler: handler)
+        #elseif canImport(AppKit)
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw VisionOCRError.invalidImage
+        }
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        return try await performScan(handler: handler)
+        #else
+        throw VisionOCRError.unsupportedPlatform
+        #endif
+    }
+
+    func scan(at url: URL) async throws -> VisionOCRResult {
+        let handler = VNImageRequestHandler(url: url, options: [:])
+        return try await performScan(handler: handler)
+    }
+
+    private func performScan(handler: VNImageRequestHandler) async throws -> VisionOCRResult {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        request.recognitionLanguages = recognitionLanguages
+
+        let observations: [VNRecognizedTextObservation] = try await withCheckedThrowingContinuation { continuation in
+            if #available(iOS 16, macOS 13, *) {
+                request.revision = VNRecognizeTextRequestRevision3
+            }
+            request.progressHandler = { _, _, progress, _ in
+                if progress >= 1.0 {
+                    // no-op, required to keep handler alive during recognition
+                }
+            }
+
+            request.completionHandler = { request, error in
+                if let error {
+                    continuation.resume(throwing: VisionOCRError.recognitionFailed(error))
+                    return
+                }
+                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                    continuation.resume(returning: [])
+                    return
+                }
+                continuation.resume(returning: observations)
+            }
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try handler.perform([request])
+                } catch {
+                    continuation.resume(throwing: VisionOCRError.recognitionFailed(error))
+                }
+            }
+        }
+
+        let recognizedStrings = observations.compactMap { observation -> (text: String, confidence: Float)? in
+            guard let candidate = observation.topCandidates(1).first else { return nil }
+            return (candidate.string, candidate.confidence)
+        }
+
+        let merchant = extractMerchant(from: recognizedStrings)
+        let date = extractDate(from: recognizedStrings)
+        let total = extractTotal(from: recognizedStrings)
+        let lineItems = extractLineItems(from: recognizedStrings)
+
+        return VisionOCRResult(merchant: merchant, date: date, total: total, lineItems: lineItems)
+    }
+
+    private func extractMerchant(from recognizedStrings: [(text: String, confidence: Float)]) -> VisionOCRConfidence<String> {
+        guard let first = recognizedStrings.first else {
+            return VisionOCRConfidence(value: nil, confidence: .zero)
+        }
+        return VisionOCRConfidence(value: first.text, confidence: first.confidence)
+    }
+
+    private func extractDate(from recognizedStrings: [(text: String, confidence: Float)]) -> VisionOCRConfidence<Date> {
+        for candidate in recognizedStrings {
+            for formatter in dateParsers {
+                if let date = formatter.date(from: candidate.text) {
+                    return VisionOCRConfidence(value: date, confidence: candidate.confidence)
+                }
+            }
+        }
+        return VisionOCRConfidence(value: nil, confidence: .zero)
+    }
+
+    private func extractTotal(from recognizedStrings: [(text: String, confidence: Float)]) -> VisionOCRConfidence<Decimal> {
+        var bestCandidate: (value: Decimal, confidence: Float)?
+
+        for candidate in recognizedStrings {
+            let lowercased = candidate.text.lowercased()
+            let containsKeyword = totalKeywords.contains { lowercased.contains($0) }
+
+            if containsKeyword, let decimal = DecimalFormatter.decimal(from: candidate.text) {
+                if let existing = bestCandidate {
+                    if candidate.confidence > existing.confidence {
+                        bestCandidate = (decimal, candidate.confidence)
+                    }
+                } else {
+                    bestCandidate = (decimal, candidate.confidence)
+                }
+            }
+        }
+
+        if let bestCandidate {
+            return VisionOCRConfidence(value: bestCandidate.value, confidence: bestCandidate.confidence)
+        }
+
+        if let fallback = recognizedStrings.compactMap({ string -> (Decimal, Float)? in
+            guard let value = DecimalFormatter.decimal(from: string.text) else { return nil }
+            return (value, string.confidence)
+        }).max(by: { lhs, rhs in lhs.0 < rhs.0 }) {
+            return VisionOCRConfidence(value: fallback.0, confidence: fallback.1)
+        }
+
+        return VisionOCRConfidence(value: nil, confidence: .zero)
+    }
+
+    private func extractLineItems(from recognizedStrings: [(text: String, confidence: Float)]) -> [VisionOCRLineItem] {
+        recognizedStrings.compactMap { candidate in
+            let tokenizer = LineItemTokenizer(text: candidate.text)
+            guard let name = tokenizer.name else { return nil }
+
+            let quantityConfidence = tokenizer.quantity != nil ? candidate.confidence : .zero
+            let priceConfidence = tokenizer.price != nil ? candidate.confidence : .zero
+
+            return VisionOCRLineItem(
+                name: .init(value: name, confidence: candidate.confidence),
+                quantity: .init(value: tokenizer.quantity, confidence: quantityConfidence),
+                price: .init(value: tokenizer.price, confidence: priceConfidence)
+            )
+        }
+    }
+}
+
+private enum DecimalFormatter {
+    static func decimal(from string: String) -> Decimal? {
+        let allowedCharacters = CharacterSet(charactersIn: "0123456789.,-")
+        let filteredScalars = string.unicodeScalars.filter { allowedCharacters.contains($0) }
+        var sanitized = String(String.UnicodeScalarView(filteredScalars)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !sanitized.isEmpty else { return nil }
+
+        if sanitized.contains(",") && !sanitized.contains(".") {
+            sanitized = sanitized.replacingOccurrences(of: ".", with: "")
+            sanitized = sanitized.replacingOccurrences(of: ",", with: ".")
+        } else {
+            sanitized = sanitized.replacingOccurrences(of: ",", with: "")
+        }
+
+        return Decimal(string: sanitized)
+    }
+}
+
+private struct LineItemTokenizer {
+    let name: String?
+    let quantity: Decimal?
+    let price: Decimal?
+
+    init(text: String) {
+        let components = text.split(separator: " ").map(String.init)
+        var quantity: Decimal?
+        var price: Decimal?
+        var nameComponents: [String] = []
+
+        for component in components {
+            if quantity == nil,
+               let decimal = DecimalFormatter.decimal(from: component),
+               component.rangeOfCharacter(from: CharacterSet.letters) == nil,
+               !component.contains(".") {
+                quantity = decimal
+                continue
+            }
+
+            if price == nil,
+               let decimal = DecimalFormatter.decimal(from: component),
+               component.contains(".") || component.contains(",") {
+                price = decimal
+                continue
+            }
+
+            nameComponents.append(component)
+        }
+
+        let sanitizedName = nameComponents.joined(separator: " ")
+
+        self.name = sanitizedName.isEmpty ? nil : sanitizedName
+        self.quantity = quantity
+        self.price = price
+    }
+}


### PR DESCRIPTION
## Summary
- add a Vision-based OCR service that extracts merchant metadata, totals, and line items with confidence metadata
- implement a barcode service with a live AVFoundation scanner, offline catalog lookup, and persistent user overrides
- add a geofencing location service that publishes enter/exit events per merchant and a CSV importer for transactions and inventory
- expose the new services through `ServiceContainer`

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cf56a3b47c8329bf1e668df0cc4236