### PR TITLE
Add share extension handling for inbox queue

### DIFF
--- a/App/CompositionRoot.swift
+++ b/App/CompositionRoot.swift
@@ -25,6 +25,9 @@ final class CompositionRoot: ObservableObject {
         let services = ServiceContainer(persistence: persistence, eventDispatcher: eventDispatcher)
         self.services = services
 
+        let importer = ShareInboxImporter(persistence: persistence, events: eventDispatcher)
+        importer.importPendingItems()
+
         let syncService = SyncService()
         let reducer = AppReducer(services: services, persistence: persistence, syncService: syncService)
         self.appStore = AppStore(initialState: AppState(), reducer: reducer)

--- a/Core/Services/ShareInboxImporter.swift
+++ b/Core/Services/ShareInboxImporter.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@MainActor
+struct ShareInboxImporter {
+    private let persistence: PersistenceController
+    private let events: EventDispatcher
+
+    init(persistence: PersistenceController, events: EventDispatcher) {
+        self.persistence = persistence
+        self.events = events
+    }
+
+    func importPendingItems() {
+        let queue = SharedInboxQueue()
+        let pendingItems = queue.dequeueAll()
+        guard !pendingItems.isEmpty else { return }
+
+        for item in pendingItems {
+            do {
+                let payload = item.makeEventPayload()
+                let json = try encodePayload(payload)
+                try persistence.eventStore.append(
+                    kind: DomainEventKind.inboxEnqueued.rawValue,
+                    payloadJSON: json,
+                    occurredAt: item.receivedAt,
+                    relatedIds: item.relatedAttachmentIds
+                )
+
+                events.post(
+                    kind: .inboxEnqueued,
+                    payload: [
+                        "inboxItemId": item.id.uuidString,
+                        "title": item.title ?? "Incoming item"
+                    ],
+                    occurredAt: item.receivedAt
+                )
+            } catch {
+                assertionFailure("Failed to import shared inbox item: \(error)")
+            }
+        }
+    }
+
+    private func encodePayload(_ payload: InboxEnqueuedPayload) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(payload)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+}

--- a/Core/Services/SharedInboxQueue.swift
+++ b/Core/Services/SharedInboxQueue.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+struct SharedInboxQueue {
+    static let appGroupIdentifier = "group.com.example.keystone"
+    private static let queueKey = "inbox.queue.pending"
+    static let attachmentsDirectoryName = "Inbox/Attachments"
+
+    private let userDefaults: UserDefaults?
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.userDefaults = UserDefaults(suiteName: Self.appGroupIdentifier)
+        self.fileManager = fileManager
+    }
+
+    func enqueue(_ item: SharedInboxItem) throws {
+        var items = try loadItems()
+        items.append(item)
+        try persist(items)
+    }
+
+    func dequeueAll() -> [SharedInboxItem] {
+        guard let userDefaults else { return [] }
+
+        do {
+            let items = try loadItems()
+            userDefaults.removeObject(forKey: Self.queueKey)
+            userDefaults.synchronize()
+            return items
+        } catch {
+            userDefaults.removeObject(forKey: Self.queueKey)
+            userDefaults.synchronize()
+            return []
+        }
+    }
+
+    func sharedContainerURL() throws -> URL {
+        guard let containerURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: Self.appGroupIdentifier) else {
+            throw SharedInboxQueueError.missingAppGroupContainer
+        }
+        return containerURL
+    }
+
+    func attachmentsDirectoryURL() throws -> URL {
+        let base = try sharedContainerURL()
+        let attachmentsDirectory = base.appendingPathComponent(Self.attachmentsDirectoryName, isDirectory: true)
+        if !fileManager.fileExists(atPath: attachmentsDirectory.path) {
+            try fileManager.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+        }
+        return attachmentsDirectory
+    }
+
+    // MARK: - Private
+
+    private func loadItems() throws -> [SharedInboxItem] {
+        guard let userDefaults else { throw SharedInboxQueueError.unavailableUserDefaults }
+        guard let data = userDefaults.data(forKey: Self.queueKey) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode([SharedInboxItem].self, from: data)
+        } catch {
+            throw SharedInboxQueueError.decodingFailed(error)
+        }
+    }
+
+    private func persist(_ items: [SharedInboxItem]) throws {
+        guard let userDefaults else { throw SharedInboxQueueError.unavailableUserDefaults }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        do {
+            let data = try encoder.encode(items)
+            userDefaults.set(data, forKey: Self.queueKey)
+            userDefaults.synchronize()
+        } catch {
+            throw SharedInboxQueueError.encodingFailed(error)
+        }
+    }
+}
+
+struct SharedInboxItem: Codable, Identifiable {
+    let id: UUID
+    let title: String?
+    let detail: String?
+    let receivedAt: Date
+    let source: SharedInboxSource
+    let suggestions: [SharedInboxSuggestion]
+    let attachments: [SharedInboxAttachment]
+
+    init(
+        id: UUID = UUID(),
+        title: String?,
+        detail: String?,
+        receivedAt: Date = .now,
+        source: SharedInboxSource = .share,
+        suggestions: [SharedInboxSuggestion],
+        attachments: [SharedInboxAttachment]
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.receivedAt = receivedAt
+        self.source = source
+        self.suggestions = suggestions
+        self.attachments = attachments
+    }
+
+    var relatedAttachmentIds: [UUID] {
+        attachments.map(\.id)
+    }
+
+    func makeEventPayload() -> InboxEnqueuedPayload {
+        InboxEnqueuedPayload(
+            title: title,
+            detail: detail,
+            source: source,
+            suggestions: suggestions,
+            attachments: attachments
+        )
+    }
+}
+
+enum SharedInboxSource: String, Codable {
+    case share
+    case camera
+    case csv
+}
+
+struct SharedInboxSuggestion: Codable, Hashable {
+    let classification: String
+    let confidence: Double?
+
+    init(classification: String, confidence: Double? = nil) {
+        self.classification = classification
+        self.confidence = confidence
+    }
+}
+
+struct SharedInboxAttachment: Codable, Identifiable {
+    let id: UUID
+    let filename: String
+    let relativePath: String
+    let uniformTypeIdentifier: String
+
+    init(id: UUID = UUID(), filename: String, relativePath: String, uniformTypeIdentifier: String) {
+        self.id = id
+        self.filename = filename
+        self.relativePath = relativePath
+        self.uniformTypeIdentifier = uniformTypeIdentifier
+    }
+}
+
+struct InboxEnqueuedPayload: Encodable {
+    let title: String?
+    let detail: String?
+    let source: SharedInboxSource
+    let suggestions: [SharedInboxSuggestion]
+    let attachments: [SharedInboxAttachment]
+}
+
+enum SharedInboxQueueError: Error {
+    case missingAppGroupContainer
+    case unavailableUserDefaults
+    case encodingFailed(Error)
+    case decodingFailed(Error)
+}

--- a/Extensions/ShareExtension/Info.plist
+++ b/Extensions/ShareExtension/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>Keystone Inbox</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Keystone Inbox</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>NSExtensionActivationRule</key>
+            <string>
+                SUBQUERY(
+                    extensionItems,
+                    $item,
+                    SUBQUERY(
+                        $item.attachments,
+                        $attachment,
+                        ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image" ||
+                        ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.adobe.pdf" ||
+                        ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text" ||
+                        ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.comma-separated-values-text"
+                    ).@count == $item.attachments.@count
+                ).@count > 0
+            </string>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.share-services</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).ShareExtensionViewController</string>
+    </dict>
+</dict>
+</plist>

--- a/Extensions/ShareExtension/ShareExtension.entitlements
+++ b/Extensions/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.example.keystone</string>
+    </array>
+</dict>
+</plist>

--- a/Extensions/ShareExtension/ShareExtensionPlaceholder.swift
+++ b/Extensions/ShareExtension/ShareExtensionPlaceholder.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-enum ShareExtensionPlaceholder {
-    static func configure() {
-        // Placeholder for share extension setup.
-    }
-}

--- a/Extensions/ShareExtension/ShareExtensionViewController.swift
+++ b/Extensions/ShareExtension/ShareExtensionViewController.swift
@@ -1,0 +1,394 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+final class ShareExtensionViewController: UIHostingController<ShareExtensionView> {
+    private let viewModel = ShareExtensionViewModel()
+
+    required init?(coder aDecoder: NSCoder) {
+        let viewModel = ShareExtensionViewModel()
+        let rootView = ShareExtensionView(viewModel: viewModel)
+        super.init(coder: aDecoder, rootView: rootView)
+        viewModel.configure(with: extensionContext)
+    }
+
+    override init(rootView: ShareExtensionView) {
+        fatalError("init(rootView:) has not been implemented")
+    }
+}
+
+struct ShareExtensionView: View {
+    @ObservedObject var viewModel: ShareExtensionViewModel
+
+    var body: some View {
+        VStack(spacing: 16) {
+            switch viewModel.state {
+            case .preparing:
+                ProgressView("Preparing…")
+                    .progressViewStyle(.circular)
+            case .processing:
+                ProgressView("Saving to Inbox…")
+                    .progressViewStyle(.circular)
+            case .success(let message):
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.green)
+                Text(message)
+                    .font(.headline)
+                Text("You can continue in Keystone.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            case .failure(let message):
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.yellow)
+                Text("Unable to Share")
+                    .font(.headline)
+                Text(message)
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                Button("Dismiss") {
+                    viewModel.cancel()
+                }
+            }
+        }
+        .padding()
+        .onAppear {
+            viewModel.beginProcessing()
+        }
+    }
+}
+
+@MainActor
+final class ShareExtensionViewModel: ObservableObject {
+    enum State {
+        case preparing
+        case processing
+        case success(message: String)
+        case failure(message: String)
+    }
+
+    @Published private(set) var state: State = .preparing
+
+    private weak var extensionContext: NSExtensionContext?
+    private var processingTask: Task<Void, Never>?
+    private let handler: ShareExtensionHandler
+
+    init(handler: ShareExtensionHandler = ShareExtensionHandler()) {
+        self.handler = handler
+    }
+
+    func configure(with context: NSExtensionContext?) {
+        guard let context else {
+            state = .failure(message: "Missing extension context.")
+            return
+        }
+        extensionContext = context
+    }
+
+    func beginProcessing() {
+        guard processingTask == nil else { return }
+        guard let context = extensionContext else { return }
+
+        state = .processing
+        processingTask = Task {
+            do {
+                let result = try await handler.process(context: context)
+                state = .success(message: result.successMessage)
+                try await Task.sleep(nanoseconds: 800_000_000)
+                completeRequest()
+            } catch {
+                state = .failure(message: error.localizedDescription)
+            }
+        }
+    }
+
+    func cancel() {
+        processingTask?.cancel()
+        extensionContext?.cancelRequest(withError: ShareExtensionError.userCancelled)
+    }
+
+    private func completeRequest() {
+        extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+    }
+}
+
+struct ShareExtensionResult {
+    let successMessage: String
+}
+
+enum ShareExtensionError: LocalizedError {
+    case unsupportedContent
+    case missingAppGroup
+    case failedToSave
+    case userCancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedContent:
+            return "The shared items are not in a supported format."
+        case .missingAppGroup:
+            return "Shared storage could not be accessed."
+        case .failedToSave:
+            return "Keystone was unable to save the shared content."
+        case .userCancelled:
+            return "The share operation was cancelled."
+        }
+    }
+}
+
+struct ShareExtensionHandler {
+    private struct LoadedAttachment {
+        let data: Data
+        let filename: String
+        let fileExtension: String
+        let uti: UTType
+        let textPreview: String?
+        let classification: SharedInboxSuggestion
+    }
+
+    private let supportedTypes: [UTType] = [
+        .image,
+        .pdf,
+        .plainText,
+        .commaSeparatedText
+    ]
+
+    private let queue: SharedInboxQueue
+
+    init(queue: SharedInboxQueue = SharedInboxQueue()) {
+        self.queue = queue
+    }
+
+    func process(context: NSExtensionContext) async throws -> ShareExtensionResult {
+        let attachments = try await loadAttachments(from: context)
+        guard !attachments.isEmpty else { throw ShareExtensionError.unsupportedContent }
+
+        let savedAttachments: [SharedInboxAttachment]
+        do {
+            savedAttachments = try save(attachments)
+        } catch let error as SharedInboxQueueError {
+            throw mapQueueError(error)
+        }
+        let suggestions = suggestionsForAttachments(attachments)
+        let title = savedAttachments.first?.filename
+        let detail = attachments.compactMap { $0.textPreview?.inboxSnippet() }.first
+
+        let inboxItem = SharedInboxItem(
+            title: title,
+            detail: detail,
+            suggestions: Array(suggestions),
+            attachments: savedAttachments
+        )
+
+        do {
+            try queue.enqueue(inboxItem)
+        } catch let error as SharedInboxQueueError {
+            throw mapQueueError(error)
+        }
+        return ShareExtensionResult(successMessage: "Added to Inbox")
+    }
+
+    private func loadAttachments(from context: NSExtensionContext) async throws -> [LoadedAttachment] {
+        guard let inputItems = context.inputItems as? [NSExtensionItem] else { return [] }
+        var loaded: [LoadedAttachment] = []
+
+        for item in inputItems {
+            guard let providers = item.attachments else { continue }
+            for provider in providers {
+                if let attachment = try await loadAttachment(from: provider) {
+                    loaded.append(attachment)
+                }
+            }
+        }
+
+        return loaded
+    }
+
+    private func loadAttachment(from provider: NSItemProvider) async throws -> LoadedAttachment? {
+        for type in supportedTypes {
+            if provider.hasItemConforming(toTypeIdentifier: type.identifier) {
+                if let attachment = try await readAttachment(from: provider, type: type) {
+                    return attachment
+                }
+            }
+        }
+        return nil
+    }
+
+    private func readAttachment(from provider: NSItemProvider, type: UTType) async throws -> LoadedAttachment? {
+        if let url = try await provider.loadFileRepresentation(for: type) {
+            return try makeAttachment(from: url, type: type)
+        }
+
+        if let data = try await provider.loadDataRepresentation(for: type) {
+            return makeAttachment(from: data, suggestedName: provider.suggestedName, type: type)
+        }
+
+        if type == .plainText, let string = try await provider.loadText() {
+            let data = Data(string.utf8)
+            return makeAttachment(from: data, suggestedName: provider.suggestedName, type: type, textPreview: string)
+        }
+
+        return nil
+    }
+
+    private func makeAttachment(from url: URL, type: UTType) throws -> LoadedAttachment {
+        let data: Data
+        if url.startAccessingSecurityScopedResource() {
+            defer { url.stopAccessingSecurityScopedResource() }
+            data = try Data(contentsOf: url)
+        } else {
+            data = try Data(contentsOf: url)
+        }
+
+        let filename = url.lastPathComponent
+        let fileExtension = url.pathExtension.nonEmpty ?? type.preferredFilenameExtension ?? "dat"
+        let preview = type == .plainText ? String(data: data, encoding: .utf8) : nil
+        return LoadedAttachment(
+            data: data,
+            filename: filename,
+            fileExtension: fileExtension,
+            uti: type,
+            textPreview: preview,
+            classification: classification(for: type)
+        )
+    }
+
+    private func makeAttachment(from data: Data, suggestedName: String?, type: UTType, textPreview: String? = nil) -> LoadedAttachment {
+        let fileExtension = type.preferredFilenameExtension ?? "dat"
+        let filename = (suggestedName ?? UUID().uuidString) + "." + fileExtension
+        let preview = textPreview ?? (type == .plainText ? String(data: data, encoding: .utf8) : nil)
+        return LoadedAttachment(
+            data: data,
+            filename: filename,
+            fileExtension: fileExtension,
+            uti: type,
+            textPreview: preview,
+            classification: classification(for: type)
+        )
+    }
+
+    private func save(_ attachments: [LoadedAttachment]) throws -> [SharedInboxAttachment] {
+        guard !attachments.isEmpty else { return [] }
+        let directory = try queue.attachmentsDirectoryURL()
+        var saved: [SharedInboxAttachment] = []
+
+        for attachment in attachments {
+            let id = UUID()
+            let filename = "\(id.uuidString).\(attachment.fileExtension)"
+            let destination = directory.appendingPathComponent(filename)
+            do {
+                try attachment.data.write(to: destination, options: [.atomic])
+            } catch {
+                throw ShareExtensionError.failedToSave
+            }
+
+            let relativePath = "\(SharedInboxQueue.attachmentsDirectoryName)/\(filename)"
+            let savedAttachment = SharedInboxAttachment(
+                id: id,
+                filename: attachment.filename,
+                relativePath: relativePath,
+                uniformTypeIdentifier: attachment.uti.identifier
+            )
+            saved.append(savedAttachment)
+        }
+
+        return saved
+    }
+
+    private func suggestionsForAttachments(_ attachments: [LoadedAttachment]) -> Set<SharedInboxSuggestion> {
+        var suggestions: Set<SharedInboxSuggestion> = []
+        for attachment in attachments {
+            suggestions.insert(attachment.classification)
+        }
+
+        if suggestions.isEmpty {
+            suggestions.insert(SharedInboxSuggestion(classification: "receipt"))
+            suggestions.insert(SharedInboxSuggestion(classification: "note"))
+            suggestions.insert(SharedInboxSuggestion(classification: "csv"))
+        }
+
+        return suggestions
+    }
+
+    private func classification(for type: UTType) -> SharedInboxSuggestion {
+        if type.conforms(to: .commaSeparatedText) {
+            return SharedInboxSuggestion(classification: "csv")
+        } else if type.conforms(to: .plainText) {
+            return SharedInboxSuggestion(classification: "note")
+        } else {
+            return SharedInboxSuggestion(classification: "receipt")
+        }
+    }
+
+    private func mapQueueError(_ error: SharedInboxQueueError) -> ShareExtensionError {
+        switch error {
+        case .missingAppGroupContainer:
+            return .missingAppGroup
+        case .unavailableUserDefaults, .encodingFailed, .decodingFailed:
+            return .failedToSave
+        }
+    }
+}
+
+private extension String {
+    func inboxSnippet(maxLength: Int = 140) -> String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > maxLength else { return trimmed }
+        let endIndex = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
+        let prefix = trimmed[..<endIndex]
+        return String(prefix) + "…"
+    }
+}
+
+private extension NSItemProvider {
+    func loadFileRepresentation(for type: UTType) async throws -> URL? {
+        try await withCheckedThrowingContinuation { continuation in
+            loadFileRepresentation(forTypeIdentifier: type.identifier) { url, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: url)
+                }
+            }
+        }
+    }
+
+    func loadDataRepresentation(for type: UTType) async throws -> Data? {
+        try await withCheckedThrowingContinuation { continuation in
+            loadDataRepresentation(forTypeIdentifier: type.identifier) { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: data)
+                }
+            }
+        }
+    }
+
+    func loadText() async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { item, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let text = item as? String {
+                    continuation.resume(returning: text)
+                } else if let data = item as? Data, let text = String(data: data, encoding: .utf8) {
+                    continuation.resume(returning: text)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var nonEmpty: String? {
+        guard let value = self, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return value
+    }
+}

--- a/Keystone.xcodeproj/project.pbxproj
+++ b/Keystone.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
         A0010000000000000000000F /* HabitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0010001000000000000000F /* HabitsView.swift */; };
         A00100000000000000000010 /* CalendarLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000010 /* CalendarLinksView.swift */; };
         A00100000000000000000011 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000011 /* SettingsView.swift */; };
-        A00100000000000000000012 /* ShareExtensionPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000012 /* ShareExtensionPlaceholder.swift */; };
         A00100000000000000000013 /* TodayWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000013 /* TodayWidget.swift */; };
         A00100000000000000000014 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000014 /* DesignSystem.swift */; };
         A00100000000000000000015 /* TestingUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000015 /* TestingUtilities.swift */; };
@@ -35,6 +34,10 @@
         A0010000000000000000001F /* TodaySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0010001000000000000001F /* TodaySummary.swift */; };
         A00100000000000000000020 /* TodaySummaryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000020 /* TodaySummaryStore.swift */; };
         A00100000000000000000021 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00100010000000000000021 /* TodayViewModel.swift */; };
+        2F9E1BE900A3409B97FE14CA /* SharedInboxQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB960B0A435D4EC8BF59EC99 /* SharedInboxQueue.swift */; };
+        46196C7533054953BCB88F59 /* ShareInboxImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB74D3BB46D4A8E89E6E43F /* ShareInboxImporter.swift */; };
+        CB781DFE4F48485DBBEF6FDA /* ShareExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D236E73F128E4D24AF880EE4 /* ShareExtensionViewController.swift */; };
+        A2A682EE1B6A40DFB52B5B7F /* SharedInboxQueue.swift in Share Extension Sources */ = {isa = PBXBuildFile; fileRef = EB960B0A435D4EC8BF59EC99 /* SharedInboxQueue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -55,7 +58,6 @@
         A0010001000000000000000F /* HabitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitsView.swift; sourceTree = "<group>"; };
         A00100010000000000000010 /* CalendarLinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarLinksView.swift; sourceTree = "<group>"; };
         A00100010000000000000011 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-        A00100010000000000000012 /* ShareExtensionPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionPlaceholder.swift; sourceTree = "<group>"; };
         A00100010000000000000013 /* TodayWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidget.swift; sourceTree = "<group>"; };
         A00100010000000000000014 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
         A00100010000000000000015 /* TestingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtilities.swift; sourceTree = "<group>"; };
@@ -70,10 +72,18 @@
         A0010001000000000000001F /* TodaySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaySummary.swift; sourceTree = "<group>"; };
         A00100010000000000000020 /* TodaySummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodaySummaryStore.swift; sourceTree = "<group>"; };
         A00100010000000000000021 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
+        EB960B0A435D4EC8BF59EC99 /* SharedInboxQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Services/SharedInboxQueue.swift; sourceTree = SOURCE_ROOT; };
+        2DB74D3BB46D4A8E89E6E43F /* ShareInboxImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Core/Services/ShareInboxImporter.swift; sourceTree = SOURCE_ROOT; };
+        D236E73F128E4D24AF880EE4 /* ShareExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions/ShareExtension/ShareExtensionViewController.swift; sourceTree = SOURCE_ROOT; };
+        52E4EABA5DE1434891C902AF /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Extensions/ShareExtension/ShareExtension.entitlements; sourceTree = SOURCE_ROOT; };
+        CE9DAF654B324F0D90D75DD2 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = wrapper.app-extension; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+        BA44CA88E67F457382246731 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Extensions/ShareExtension/Info.plist; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
         A00100020000000000000000 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
+        };
+        A9372265B2D345F3AEBD8E64 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
         };
 /* End PBXFrameworksBuildPhase section */
 
@@ -89,6 +99,7 @@
                 A00100010000000000000017 /* Keystone.entitlements */,
                 A00100030000000000000006 /* Resources */,
                 A00100010000000000000018 /* Keystone.app */,
+                CE9DAF654B324F0D90D75DD2 /* ShareExtension.appex */,
             );
             sourceTree = "<group>";
         };
@@ -213,6 +224,8 @@
             isa = PBXGroup;
             children = (
                 A00100010000000000000008 /* ServiceContainer.swift */,
+                EB960B0A435D4EC8BF59EC99 /* SharedInboxQueue.swift */,
+                2DB74D3BB46D4A8E89E6E43F /* ShareInboxImporter.swift */,
                 A0010001000000000000001C /* BudgetPublisher.swift */,
                 A00100010000000000000020 /* TodaySummaryStore.swift */,
             );
@@ -295,7 +308,9 @@
         A00100030000000000000016 /* ShareExtension */ = {
             isa = PBXGroup;
             children = (
-                A00100010000000000000012 /* ShareExtensionPlaceholder.swift */,
+                D236E73F128E4D24AF880EE4 /* ShareExtensionViewController.swift */,
+                BA44CA88E67F457382246731 /* Info.plist */,
+                52E4EABA5DE1434891C902AF /* ShareExtension.entitlements */,
             );
             path = ShareExtension;
             sourceTree = "<group>";
@@ -342,6 +357,21 @@
             productReference = A00100010000000000000018 /* Keystone.app */;
             productType = "com.apple.product-type.application";
         };
+        EA0CFDDED06C421280122AC6 /* ShareExtension */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 3E79F98BE5244D00B5FFED78 /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+            buildPhases = (
+                E6AB638C054543A8B51A4073 /* Sources */,
+                A9372265B2D345F3AEBD8E64 /* Frameworks */,
+                729C8671842149B69F63065A /* Resources */,
+            );
+            buildRules = ();
+            dependencies = ();
+            name = ShareExtension;
+            productName = ShareExtension;
+            productReference = CE9DAF654B324F0D90D75DD2 /* ShareExtension.appex */;
+            productType = "com.apple.product-type.app-extension";
+        };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -353,6 +383,11 @@
                 LastUpgradeCheck = 1530;
                 TargetAttributes = {
                     A00100040000000000000000 = {
+                        CreatedOnToolsVersion = 15.3;
+                        DevelopmentTeam = "";
+                        ProvisioningStyle = Automatic;
+                    };
+                    EA0CFDDED06C421280122AC6 = {
                         CreatedOnToolsVersion = 15.3;
                         DevelopmentTeam = "";
                         ProvisioningStyle = Automatic;
@@ -372,12 +407,14 @@
             projectRoot = "";
             targets = (
                 A00100040000000000000000 /* Keystone */,
+                EA0CFDDED06C421280122AC6 /* ShareExtension */,
             );
         };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
         A00100060000000000000000 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); };
+        729C8671842149B69F63065A /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -391,6 +428,8 @@
                 A00100000000000000000006 /* PersistenceController.swift in Sources */,
                 A00100000000000000000007 /* SyncService.swift in Sources */,
                 A00100000000000000000008 /* ServiceContainer.swift in Sources */,
+                2F9E1BE900A3409B97FE14CA /* SharedInboxQueue.swift in Sources */,
+                46196C7533054953BCB88F59 /* ShareInboxImporter.swift in Sources */,
                 A00100000000000000000020 /* TodaySummaryStore.swift in Sources */,
                 A00100000000000000000009 /* IntentHandling.swift in Sources */,
                 A0010000000000000000000A /* TodayView.swift in Sources */,
@@ -402,7 +441,6 @@
                 A0010000000000000000000F /* HabitsView.swift in Sources */,
                 A00100000000000000000010 /* CalendarLinksView.swift in Sources */,
                 A00100000000000000000011 /* SettingsView.swift in Sources */,
-                A00100000000000000000012 /* ShareExtensionPlaceholder.swift in Sources */,
                 A00100000000000000000013 /* WidgetsPlaceholder.swift in Sources */,
                 A00100000000000000000014 /* DesignSystem.swift in Sources */,
                 A00100000000000000000015 /* TestingUtilities.swift in Sources */,
@@ -414,6 +452,14 @@
                 A0010000000000000000001B /* InventoryOperationTracker.swift in Sources */,
                 A0010000000000000000001C /* BudgetPublisher.swift in Sources */,
                 A0010000000000000000001D /* CurrencyMath.swift in Sources */,
+            );
+        };
+        E6AB638C054543A8B51A4073 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                CB781DFE4F48485DBBEF6FDA /* ShareExtensionViewController.swift in Sources */,
+                A2A682EE1B6A40DFB52B5B7F /* SharedInboxQueue.swift in Share Extension Sources */,
             );
         };
 /* End PBXSourcesBuildPhase section */
@@ -545,6 +591,49 @@
             };
             name = Release;
         };
+        33903EF85960426AACA37978 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CODE_SIGN_ENTITLEMENTS = Extensions/ShareExtension/ShareExtension.entitlements;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = NO;
+                INFOPLIST_FILE = Extensions/ShareExtension/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.example.Keystone.ShareExtension;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SKIP_INSTALL = YES;
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                DEVELOPMENT_TEAM = "";
+            };
+            name = Debug;
+        };
+        D4619A45E1A74C029198DC5C /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CODE_SIGN_ENTITLEMENTS = Extensions/ShareExtension/ShareExtension.entitlements;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = NO;
+                INFOPLIST_FILE = Extensions/ShareExtension/Info.plist;
+                IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.example.Keystone.ShareExtension;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SKIP_INSTALL = YES;
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                DEVELOPMENT_TEAM = "";
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -565,6 +654,15 @@
             );
             defaultConfigurationIsVisible = 0;
             defaultConfigurationName = Debug;
+        };
+        3E79F98BE5244D00B5FFED78 /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                33903EF85960426AACA37978 /* Debug */,
+                D4619A45E1A74C029198DC5C /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
         };
 /* End XCConfigurationList section */
     };


### PR DESCRIPTION
## Summary
- add a shared inbox queue and importer so pending items from extensions are persisted and dispatched in the main app
- implement the share extension UI/controller to accept supported file types, store attachments in the app group, and enqueue inbox payloads
- configure the share extension target, activation rule, and entitlements for the new app group workflow

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68d01cccf1548329abe083a262ab1c60