### PR TITLE
Implement CloudKit sync service and settings controls

### DIFF
--- a/App/CompositionRoot.swift
+++ b/App/CompositionRoot.swift
@@ -22,13 +22,17 @@ final class CompositionRoot: ObservableObject {
         let eventDispatcher = EventDispatcher()
         self.eventDispatcher = eventDispatcher
 
-        let services = ServiceContainer(persistence: persistence, eventDispatcher: eventDispatcher)
+        let syncService = SyncService(persistence: persistence)
+        let services = ServiceContainer(
+            persistence: persistence,
+            eventDispatcher: eventDispatcher,
+            syncService: syncService
+        )
         self.services = services
 
         let importer = ShareInboxImporter(persistence: persistence, events: eventDispatcher)
         importer.importPendingItems()
 
-        let syncService = SyncService()
         let reducer = AppReducer(services: services, persistence: persistence, syncService: syncService)
         self.appStore = AppStore(initialState: AppState(), reducer: reducer)
 

--- a/Core/Intents/IntentDependencies.swift
+++ b/Core/Intents/IntentDependencies.swift
@@ -15,9 +15,11 @@ final class IntentDependencyContainerImplementation {
         do {
             let persistence = try PersistenceController()
             let dispatcher = EventDispatcher()
+            let syncService = SyncService(persistence: persistence)
             self.services = ServiceContainer(
                 persistence: persistence,
-                eventDispatcher: dispatcher
+                eventDispatcher: dispatcher,
+                syncService: syncService
             )
         } catch {
             fatalError("Failed to build intent dependencies: \(error)")

--- a/Core/Sync/SyncModels.swift
+++ b/Core/Sync/SyncModels.swift
@@ -1,0 +1,207 @@
+import Foundation
+import CloudKit
+
+enum SyncFeature: String, CaseIterable, Identifiable, Codable, Sendable {
+    case core
+    case finances
+    case merchants
+    case transactions
+    case inventory
+    case shopping
+    case habits
+    case rules
+    case attachments
+    case events
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .core:
+            return "Profile"
+        case .finances:
+            return "Accounts"
+        case .merchants:
+            return "Merchants"
+        case .transactions:
+            return "Transactions"
+        case .inventory:
+            return "Inventory"
+        case .shopping:
+            return "Shopping"
+        case .habits:
+            return "Habits"
+        case .rules:
+            return "Rules"
+        case .attachments:
+            return "Attachments"
+        case .events:
+            return "Activity Log"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .core:
+            return "person.crop.circle"
+        case .finances:
+            return "building.columns"
+        case .merchants:
+            return "building.2"
+        case .transactions:
+            return "arrow.right.arrow.left"
+        case .inventory:
+            return "shippingbox"
+        case .shopping:
+            return "cart"
+        case .habits:
+            return "repeat"
+        case .rules:
+            return "switch.2"
+        case .attachments:
+            return "paperclip"
+        case .events:
+            return "clock"
+        }
+    }
+}
+
+struct SyncConfiguration: Codable, Equatable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case isEnabled
+        case featurePermissions
+    }
+
+    var isEnabled: Bool
+    private var featurePermissions: [SyncFeature: Bool]
+
+    init(isEnabled: Bool = true, featurePermissions: [SyncFeature: Bool] = [:]) {
+        self.isEnabled = isEnabled
+        var permissions = [SyncFeature: Bool]()
+        for feature in SyncFeature.allCases {
+            permissions[feature] = featurePermissions[feature] ?? true
+        }
+        self.featurePermissions = permissions
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
+        let rawPermissions = try container.decodeIfPresent([String: Bool].self, forKey: .featurePermissions) ?? [:]
+        var permissions = [SyncFeature: Bool]()
+        for feature in SyncFeature.allCases {
+            permissions[feature] = rawPermissions[feature.rawValue] ?? true
+        }
+        self.isEnabled = isEnabled
+        self.featurePermissions = permissions
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        let rawPermissions = Dictionary(uniqueKeysWithValues: featurePermissions.map { ($0.key.rawValue, $0.value) })
+        try container.encode(rawPermissions, forKey: .featurePermissions)
+    }
+
+    func allows(_ feature: SyncFeature) -> Bool {
+        featurePermissions[feature, default: true]
+    }
+
+    mutating func setFeature(_ feature: SyncFeature, enabled: Bool) {
+        featurePermissions[feature] = enabled
+    }
+
+    mutating func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+    }
+}
+
+enum SyncStatus: Equatable, Sendable {
+    case idle(lastSync: Date?)
+    case syncing
+    case disabled
+    case error(message: String, lastSync: Date?)
+
+    var lastSyncDate: Date? {
+        switch self {
+        case let .idle(date):
+            return date
+        case let .error(_, date):
+            return date
+        case .syncing, .disabled:
+            return nil
+        }
+    }
+
+    var isSyncing: Bool {
+        if case .syncing = self { return true }
+        return false
+    }
+}
+
+enum SyncEntity: String, CaseIterable, Identifiable, Codable, Sendable {
+    case appUser = "AppUser"
+    case account = "Account"
+    case merchant = "Merchant"
+    case transaction = "Transaction"
+    case inventoryItem = "InventoryItem"
+    case locationBin = "LocationBin"
+    case shoppingList = "ShoppingList"
+    case shoppingListLine = "ShoppingListLine"
+    case habit = "Habit"
+    case taskLink = "TaskLink"
+    case calendarLink = "CalendarLink"
+    case attachment = "Attachment"
+    case budgetEnvelope = "BudgetEnvelope"
+    case personLink = "PersonLink"
+    case ruleSpec = "RuleSpec"
+    case eventRecord = "EventRecord"
+
+    var id: String { rawValue }
+
+    var recordType: String { rawValue }
+
+    var zoneID: CKRecordZone.ID {
+        CKRecordZone.ID(zoneName: "Keystone\(rawValue)", ownerName: CKCurrentUserDefaultName)
+    }
+
+    var feature: SyncFeature {
+        switch self {
+        case .appUser:
+            return .core
+        case .account:
+            return .finances
+        case .merchant:
+            return .merchants
+        case .transaction:
+            return .transactions
+        case .inventoryItem, .locationBin:
+            return .inventory
+        case .shoppingList, .shoppingListLine:
+            return .shopping
+        case .habit, .taskLink, .calendarLink:
+            return .habits
+        case .attachment:
+            return .attachments
+        case .budgetEnvelope:
+            return .finances
+        case .personLink:
+            return .core
+        case .ruleSpec:
+            return .rules
+        case .eventRecord:
+            return .events
+        }
+    }
+}
+
+struct SyncPayload: Sendable {
+    let id: UUID
+    let data: Data
+    let checksum: String
+}
+
+struct SyncRecordMetadata: Codable, Sendable {
+    var checksum: String
+    var lastSynced: Date
+}

--- a/Core/Sync/SyncService.swift
+++ b/Core/Sync/SyncService.swift
@@ -1,7 +1,861 @@
+import CloudKit
+import CryptoKit
 import Foundation
+import SwiftData
 
 actor SyncService {
-    func synchronize() async {
-        // Placeholder for CloudKit synchronization logic.
+    private struct AnySyncAdapter {
+        let entity: SyncEntity
+        let feature: SyncFeature
+        let fetchLocal: @MainActor (PersistenceController) throws -> [SyncPayload]
+        let applyRemote: @MainActor (PersistenceController, SyncPayload) throws -> Void
+        let deleteLocal: @MainActor (PersistenceController, UUID) throws -> Void
     }
+
+    private enum DefaultsKey {
+        static let configuration = "SyncService.Configuration"
+
+        static func changeTokenKey(for entity: SyncEntity) -> String {
+            "SyncService.ChangeToken.\(entity.rawValue)"
+        }
+
+        static func metadataKey(for entity: SyncEntity) -> String {
+            "SyncService.Metadata.\(entity.rawValue)"
+        }
+    }
+
+    private let persistence: PersistenceController
+    private let database: CKDatabase?
+    private let defaults: UserDefaults
+    private var configuration: SyncConfiguration
+    private var status: SyncStatus
+    private var changeTokens: [SyncEntity: CKServerChangeToken]
+    private var recordMetadata: [SyncEntity: [UUID: SyncRecordMetadata]]
+    private var isSyncing = false
+    private var statusObservers: [UUID: AsyncStream<SyncStatus>.Continuation] = [:]
+    private var configurationObservers: [UUID: AsyncStream<SyncConfiguration>.Continuation] = [:]
+
+    private static let adapters: [SyncEntity: AnySyncAdapter] = {
+        var adapters: [SyncEntity: AnySyncAdapter] = [:]
+
+        adapters[.appUser] = AnySyncAdapter(
+            entity: .appUser,
+            feature: .core,
+            fetchLocal: { persistence in
+                let models = try persistence.appUsers.fetch()
+                return try models.map { model in
+                    let snapshot = AppUserSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.identifier, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(AppUserSnapshot.self, from: payload.data)
+                if let existing = try persistence.appUsers.first(where: #Predicate { $0.identifier == snapshot.identifier }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let user = snapshot.makeModel()
+                    persistence.mainContext.insert(user)
+                    try persistence.save()
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.appUsers.delete(predicate: #Predicate { $0.identifier == identifier })
+            }
+        )
+
+        adapters[.account] = AnySyncAdapter(
+            entity: .account,
+            feature: .finances,
+            fetchLocal: { persistence in
+                let models = try persistence.accounts.fetch()
+                return try models.map { model in
+                    let snapshot = AccountSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(AccountSnapshot.self, from: payload.data)
+                if let existing = try persistence.accounts.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let account = try snapshot.makeModel()
+                    try persistence.accounts.insert(account)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.accounts.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.merchant] = AnySyncAdapter(
+            entity: .merchant,
+            feature: .merchants,
+            fetchLocal: { persistence in
+                let models = try persistence.merchants.fetch()
+                return try models.map { model in
+                    let snapshot = MerchantSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(MerchantSnapshot.self, from: payload.data)
+                if let existing = try persistence.merchants.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let merchant = try snapshot.makeModel()
+                    try persistence.merchants.insert(merchant)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.merchants.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.transaction] = AnySyncAdapter(
+            entity: .transaction,
+            feature: .transactions,
+            fetchLocal: { persistence in
+                let models = try persistence.transactions.fetch()
+                return try models.map { model in
+                    let snapshot = TransactionSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(TransactionSnapshot.self, from: payload.data)
+                if let existing = try persistence.transactions.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let transaction = try snapshot.makeModel()
+                    try persistence.transactions.insert(transaction)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.transactions.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.inventoryItem] = AnySyncAdapter(
+            entity: .inventoryItem,
+            feature: .inventory,
+            fetchLocal: { persistence in
+                let models = try persistence.inventoryItems.fetch()
+                return try models.map { model in
+                    let snapshot = InventoryItemSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(InventoryItemSnapshot.self, from: payload.data)
+                if let existing = try persistence.inventoryItems.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let item = try snapshot.makeModel()
+                    try persistence.inventoryItems.insert(item)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.inventoryItems.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.locationBin] = AnySyncAdapter(
+            entity: .locationBin,
+            feature: .inventory,
+            fetchLocal: { persistence in
+                let models = try persistence.locationBins.fetch()
+                return try models.map { model in
+                    let snapshot = LocationBinSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(LocationBinSnapshot.self, from: payload.data)
+                if let existing = try persistence.locationBins.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let location = try snapshot.makeModel()
+                    try persistence.locationBins.insert(location)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.locationBins.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.shoppingList] = AnySyncAdapter(
+            entity: .shoppingList,
+            feature: .shopping,
+            fetchLocal: { persistence in
+                let models = try persistence.shoppingLists.fetch()
+                return try models.map { model in
+                    let snapshot = ShoppingListSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(ShoppingListSnapshot.self, from: payload.data)
+                if let existing = try persistence.shoppingLists.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let list = try snapshot.makeModel()
+                    try persistence.shoppingLists.insert(list)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.shoppingLists.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.shoppingListLine] = AnySyncAdapter(
+            entity: .shoppingListLine,
+            feature: .shopping,
+            fetchLocal: { persistence in
+                let models = try persistence.shoppingListLines.fetch()
+                return try models.map { model in
+                    let snapshot = ShoppingListLineSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(ShoppingListLineSnapshot.self, from: payload.data)
+                let list: ShoppingList?
+                if let listId = snapshot.listId {
+                    list = try persistence.shoppingLists.first(where: #Predicate { $0.id == listId })
+                } else {
+                    list = nil
+                }
+                if let existing = try persistence.shoppingListLines.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing, list: list)
+                    try persistence.save()
+                } else {
+                    let line = try snapshot.makeModel(list: list)
+                    try persistence.shoppingListLines.insert(line)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.shoppingListLines.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.habit] = AnySyncAdapter(
+            entity: .habit,
+            feature: .habits,
+            fetchLocal: { persistence in
+                let models = try persistence.habits.fetch()
+                return try models.map { model in
+                    let snapshot = HabitSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(HabitSnapshot.self, from: payload.data)
+                if let existing = try persistence.habits.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let habit = try snapshot.makeModel()
+                    try persistence.habits.insert(habit)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.habits.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.taskLink] = AnySyncAdapter(
+            entity: .taskLink,
+            feature: .habits,
+            fetchLocal: { persistence in
+                let models = try persistence.taskLinks.fetch()
+                return try models.map { model in
+                    let snapshot = TaskLinkSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(TaskLinkSnapshot.self, from: payload.data)
+                if let existing = try persistence.taskLinks.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let link = try snapshot.makeModel()
+                    try persistence.taskLinks.insert(link)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.taskLinks.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.calendarLink] = AnySyncAdapter(
+            entity: .calendarLink,
+            feature: .habits,
+            fetchLocal: { persistence in
+                let models = try persistence.calendarLinks.fetch()
+                return try models.map { model in
+                    let snapshot = CalendarLinkSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(CalendarLinkSnapshot.self, from: payload.data)
+                if let existing = try persistence.calendarLinks.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let link = try snapshot.makeModel()
+                    try persistence.calendarLinks.insert(link)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.calendarLinks.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.attachment] = AnySyncAdapter(
+            entity: .attachment,
+            feature: .attachments,
+            fetchLocal: { persistence in
+                let models = try persistence.attachments.fetch()
+                return try models.map { model in
+                    let snapshot = AttachmentSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(AttachmentSnapshot.self, from: payload.data)
+                if let existing = try persistence.attachments.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let attachment = try snapshot.makeModel()
+                    try persistence.attachments.insert(attachment)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.attachments.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.budgetEnvelope] = AnySyncAdapter(
+            entity: .budgetEnvelope,
+            feature: .finances,
+            fetchLocal: { persistence in
+                let models = try persistence.budgetEnvelopes.fetch()
+                return try models.map { model in
+                    let snapshot = BudgetEnvelopeSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(BudgetEnvelopeSnapshot.self, from: payload.data)
+                if let existing = try persistence.budgetEnvelopes.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let envelope = try snapshot.makeModel()
+                    try persistence.budgetEnvelopes.insert(envelope)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.budgetEnvelopes.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.personLink] = AnySyncAdapter(
+            entity: .personLink,
+            feature: .core,
+            fetchLocal: { persistence in
+                let models = try persistence.personLinks.fetch()
+                return try models.map { model in
+                    let snapshot = PersonLinkSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(PersonLinkSnapshot.self, from: payload.data)
+                if let existing = try persistence.personLinks.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let link = try snapshot.makeModel()
+                    try persistence.personLinks.insert(link)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.personLinks.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.ruleSpec] = AnySyncAdapter(
+            entity: .ruleSpec,
+            feature: .rules,
+            fetchLocal: { persistence in
+                let models = try persistence.ruleSpecs.fetch()
+                return try models.map { model in
+                    let snapshot = RuleSpecSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(RuleSpecSnapshot.self, from: payload.data)
+                if let existing = try persistence.ruleSpecs.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let rule = try snapshot.makeModel()
+                    try persistence.ruleSpecs.insert(rule)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.ruleSpecs.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        adapters[.eventRecord] = AnySyncAdapter(
+            entity: .eventRecord,
+            feature: .events,
+            fetchLocal: { persistence in
+                let models = try persistence.eventRecords.fetch()
+                return try models.map { model in
+                    let snapshot = EventRecordSnapshot(model: model)
+                    let data = try JSONEncoder().encode(snapshot)
+                    return SyncPayload(id: snapshot.id, data: data, checksum: checksum(for: data))
+                }
+            },
+            applyRemote: { persistence, payload in
+                let snapshot = try JSONDecoder().decode(EventRecordSnapshot.self, from: payload.data)
+                if let existing = try persistence.eventRecords.first(where: #Predicate { $0.id == snapshot.id }) {
+                    snapshot.apply(to: existing)
+                    try persistence.save()
+                } else {
+                    let record = try snapshot.makeModel()
+                    try persistence.eventRecords.insert(record)
+                }
+            },
+            deleteLocal: { persistence, identifier in
+                _ = try persistence.eventRecords.delete(predicate: #Predicate { $0.id == identifier })
+            }
+        )
+
+        return adapters
+    }()
+
+    init(
+        persistence: PersistenceController,
+        container: CKContainer = .default(),
+        defaults: UserDefaults = .standard,
+        isCloudKitEnabled: Bool = true
+    ) {
+        self.persistence = persistence
+        self.database = isCloudKitEnabled ? container.privateCloudDatabase : nil
+        self.defaults = defaults
+        self.configuration = Self.loadConfiguration(from: defaults)
+        if configuration.isEnabled {
+            self.status = .idle(lastSync: nil)
+        } else {
+            self.status = .disabled
+        }
+        self.changeTokens = [:]
+        self.recordMetadata = [:]
+        self.loadPersistedTokens()
+        self.loadPersistedMetadata()
+    }
+
+    func configurationStream() -> AsyncStream<SyncConfiguration> {
+        AsyncStream { continuation in
+            let id = UUID()
+            continuation.yield(configuration)
+            continuation.onTermination = { _ in
+                Task { await self.removeConfigurationObserver(id) }
+            }
+            configurationObservers[id] = continuation
+        }
+    }
+
+    func statusStream() -> AsyncStream<SyncStatus> {
+        AsyncStream { continuation in
+            let id = UUID()
+            continuation.yield(status)
+            continuation.onTermination = { _ in
+                Task { await self.removeStatusObserver(id) }
+            }
+            statusObservers[id] = continuation
+        }
+    }
+
+    func currentConfiguration() -> SyncConfiguration {
+        configuration
+    }
+
+    func currentStatus() -> SyncStatus {
+        status
+    }
+
+    func setSyncEnabled(_ isEnabled: Bool) async {
+        configuration.setEnabled(isEnabled)
+        persistConfiguration()
+        if isEnabled {
+            await updateStatus(.idle(lastSync: status.lastSyncDate))
+        } else {
+            await updateStatus(.disabled)
+        }
+        broadcastConfiguration()
+    }
+
+    func setFeature(_ feature: SyncFeature, enabled: Bool) async {
+        configuration.setFeature(feature, enabled: enabled)
+        persistConfiguration()
+        broadcastConfiguration()
+    }
+
+    func synchronize() async {
+        guard configuration.isEnabled else {
+            await updateStatus(.disabled)
+            return
+        }
+        guard !isSyncing else { return }
+        isSyncing = true
+        await updateStatus(.syncing)
+        let adapters = activeAdapters()
+        do {
+            try await ensureZones(for: adapters)
+            try await pushLocalChanges(using: adapters)
+            try await fetchRemoteChanges(using: adapters)
+            let now = Date()
+            await updateStatus(.idle(lastSync: now))
+        } catch {
+            await updateStatus(.error(message: error.localizedDescription, lastSync: status.lastSyncDate))
+        }
+        isSyncing = false
+    }
+
+    // MARK: - Persistence Helpers
+
+    private func activeAdapters() -> [AnySyncAdapter] {
+        Self.adapters.values.filter { configuration.allows($0.feature) }
+    }
+
+    private func loadPersistedTokens() {
+        for entity in SyncEntity.allCases {
+            let key = DefaultsKey.changeTokenKey(for: entity)
+            guard let data = defaults.data(forKey: key) else { continue }
+            if let token = try? NSKeyedUnarchiver.unarchivedObject(ofClass: CKServerChangeToken.self, from: data) {
+                changeTokens[entity] = token
+            }
+        }
+    }
+
+    private func loadPersistedMetadata() {
+        let decoder = JSONDecoder()
+        for entity in SyncEntity.allCases {
+            let key = DefaultsKey.metadataKey(for: entity)
+            guard let data = defaults.data(forKey: key) else { continue }
+            if let raw = try? decoder.decode([String: SyncRecordMetadata].self, from: data) {
+                let mapped = Dictionary(uniqueKeysWithValues: raw.compactMap { key, value in
+                    guard let id = UUID(uuidString: key) else { return nil }
+                    return (id, value)
+                })
+                recordMetadata[entity] = mapped
+            }
+        }
+    }
+
+    private func persistConfiguration() {
+        if let data = try? JSONEncoder().encode(configuration) {
+            defaults.set(data, forKey: DefaultsKey.configuration)
+        }
+    }
+
+    private func persistChangeToken(_ token: CKServerChangeToken?, for entity: SyncEntity) {
+        let key = DefaultsKey.changeTokenKey(for: entity)
+        guard let token else {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        if let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true) {
+            defaults.set(data, forKey: key)
+        }
+    }
+
+    private func persistMetadata(for entity: SyncEntity) {
+        let key = DefaultsKey.metadataKey(for: entity)
+        guard let metadata = recordMetadata[entity], !metadata.isEmpty else {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        let raw = Dictionary(uniqueKeysWithValues: metadata.map { ($0.key.uuidString, $0.value) })
+        if let data = try? JSONEncoder().encode(raw) {
+            defaults.set(data, forKey: key)
+        }
+    }
+
+    private func removeStatusObserver(_ id: UUID) {
+        statusObservers[id] = nil
+    }
+
+    private func removeConfigurationObserver(_ id: UUID) {
+        configurationObservers[id] = nil
+    }
+
+    private func broadcastConfiguration() {
+        for continuation in configurationObservers.values {
+            continuation.yield(configuration)
+        }
+    }
+
+    private func updateStatus(_ newStatus: SyncStatus) async {
+        status = newStatus
+        for continuation in statusObservers.values {
+            continuation.yield(newStatus)
+        }
+    }
+
+    private static func loadConfiguration(from defaults: UserDefaults) -> SyncConfiguration {
+        if let data = defaults.data(forKey: DefaultsKey.configuration),
+           let configuration = try? JSONDecoder().decode(SyncConfiguration.self, from: data) {
+            return configuration
+        }
+        return SyncConfiguration()
+    }
+
+    // MARK: - CloudKit Operations
+
+    private func ensureZones(for adapters: [AnySyncAdapter]) async throws {
+        guard let database else { return }
+        let zones = adapters.map { CKRecordZone(zoneID: $0.entity.zoneID) }
+        guard !zones.isEmpty else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            let operation = CKModifyRecordZonesOperation(recordZonesToSave: zones, recordZoneIDsToDelete: nil)
+            operation.modifyRecordZonesResultBlock = { result in
+                continuation.resume(with: result)
+            }
+            operation.qualityOfService = .utility
+            operation.configuration.isLongLived = true
+            database.add(operation)
+        }
+    }
+
+    private func pushLocalChanges(using adapters: [AnySyncAdapter]) async throws {
+        guard !adapters.isEmpty else { return }
+        let payloads = try await collectLocalPayloads(adapters: adapters)
+        guard let database else {
+            let now = Date()
+            for (entity, payloadList) in payloads {
+                var metadata = recordMetadata[entity, default: [:]]
+                for payload in payloadList {
+                    metadata[payload.id] = SyncRecordMetadata(checksum: payload.checksum, lastSynced: now)
+                }
+                recordMetadata[entity] = metadata
+                persistMetadata(for: entity)
+            }
+            return
+        }
+
+        var recordsToSave: [CKRecord] = []
+        var recordsToDelete: [CKRecord.ID] = []
+
+        for adapter in adapters {
+            let entityPayloads = payloads[adapter.entity] ?? []
+            let metadata = recordMetadata[adapter.entity] ?? [:]
+            let payloadIDs = Set(entityPayloads.map { $0.id })
+            let knownIDs = Set(metadata.keys)
+            let removed = knownIDs.subtracting(payloadIDs)
+            for id in removed {
+                recordsToDelete.append(CKRecord.ID(recordName: id.uuidString, zoneID: adapter.entity.zoneID))
+            }
+            for payload in entityPayloads {
+                let existing = metadata[payload.id]
+                if existing?.checksum == payload.checksum { continue }
+                let recordID = CKRecord.ID(recordName: payload.id.uuidString, zoneID: adapter.entity.zoneID)
+                let record = CKRecord(recordType: adapter.entity.recordType, recordID: recordID)
+                record["payload"] = payload.data as CKRecordValue
+                record["checksum"] = payload.checksum as CKRecordValue
+                record["modifiedAt"] = Date() as CKRecordValue
+                record["feature"] = adapter.feature.rawValue as CKRecordValue
+                recordsToSave.append(record)
+            }
+        }
+
+        guard !recordsToSave.isEmpty || !recordsToDelete.isEmpty else { return }
+
+        try await withCheckedThrowingContinuation { continuation in
+            let operation = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: recordsToDelete)
+            operation.savePolicy = .allKeys
+            operation.isAtomic = false
+            operation.configuration.isLongLived = true
+            operation.qualityOfService = .utility
+            operation.modifyRecordsResultBlock = { result in
+                continuation.resume(with: result)
+            }
+            database.add(operation)
+        }
+
+        let now = Date()
+        for adapter in adapters {
+            var metadata = recordMetadata[adapter.entity, default: [:]]
+            let entityPayloads = payloads[adapter.entity] ?? []
+            let payloadMap = Dictionary(uniqueKeysWithValues: entityPayloads.map { ($0.id, $0) })
+            let payloadIDs = Set(entityPayloads.map { $0.id })
+            for id in payloadIDs {
+                if let payload = payloadMap[id] {
+                    metadata[id] = SyncRecordMetadata(checksum: payload.checksum, lastSynced: now)
+                }
+            }
+            let knownIDs = Set(metadata.keys)
+            let removed = knownIDs.subtracting(payloadIDs)
+            for id in removed {
+                metadata.removeValue(forKey: id)
+            }
+            recordMetadata[adapter.entity] = metadata
+            persistMetadata(for: adapter.entity)
+        }
+    }
+
+    private func fetchRemoteChanges(using adapters: [AnySyncAdapter]) async throws {
+        guard let database else { return }
+        let zoneIDs = adapters.map { $0.entity.zoneID }
+        guard !zoneIDs.isEmpty else { return }
+
+        var configurations: [CKRecordZone.ID: CKFetchRecordZoneChangesOperation.ZoneConfiguration] = [:]
+        for adapter in adapters {
+            let configuration = CKFetchRecordZoneChangesOperation.ZoneConfiguration(previousServerChangeToken: changeTokens[adapter.entity])
+            configurations[adapter.entity.zoneID] = configuration
+        }
+
+        let adapterMap = Dictionary(uniqueKeysWithValues: adapters.map { ($0.entity.zoneID, $0) })
+        let lock = NSLock()
+        var changed: [(AnySyncAdapter, SyncPayload, Date?)] = []
+        var deleted: [(AnySyncAdapter, UUID)] = []
+
+        try await withCheckedThrowingContinuation { continuation in
+            let operation = CKFetchRecordZoneChangesOperation(recordZoneIDs: zoneIDs, configurationsByRecordZoneID: configurations)
+            operation.recordChangedBlock = { record in
+                guard let adapter = adapterMap[record.recordID.zoneID],
+                      let data = record["payload"] as? Data,
+                      let checksum = record["checksum"] as? String,
+                      let uuid = UUID(uuidString: record.recordID.recordName) else { return }
+                let payload = SyncPayload(id: uuid, data: data, checksum: checksum)
+                lock.lock()
+                changed.append((adapter, payload, record.modificationDate))
+                lock.unlock()
+            }
+            operation.recordWithIDWasDeletedBlock = { recordID, _ in
+                guard let adapter = adapterMap[recordID.zoneID],
+                      let uuid = UUID(uuidString: recordID.recordName) else { return }
+                lock.lock()
+                deleted.append((adapter, uuid))
+                lock.unlock()
+            }
+            operation.recordZoneChangeTokensUpdatedBlock = { zoneID, token, _, _ in
+                guard let entity = adapterMap[zoneID]?.entity, let token else { return }
+                Task { await self.storeChangeToken(token, for: entity) }
+            }
+            operation.recordZoneFetchCompletionBlock = { zoneID, token, _, _, _ in
+                if let entity = adapterMap[zoneID]?.entity {
+                    Task { await self.storeChangeToken(token, for: entity) }
+                }
+            }
+            operation.fetchRecordZoneChangesResultBlock = { result in
+                continuation.resume(with: result)
+            }
+            operation.configuration.isLongLived = true
+            operation.qualityOfService = .utility
+            database.add(operation)
+        }
+
+        for (adapter, payload, modifiedDate) in changed {
+            await applyRemoteChange(adapter: adapter, payload: payload, modifiedDate: modifiedDate)
+        }
+        for (adapter, identifier) in deleted {
+            await applyRemoteDeletion(adapter: adapter, identifier: identifier)
+        }
+    }
+
+    private func applyRemoteChange(adapter: AnySyncAdapter, payload: SyncPayload, modifiedDate: Date?) async {
+        let metadata = recordMetadata[adapter.entity] ?? [:]
+        if let existing = metadata[payload.id] {
+            if existing.checksum == payload.checksum {
+                if let modifiedDate, modifiedDate <= existing.lastSynced { return }
+            } else if let modifiedDate, modifiedDate <= existing.lastSynced {
+                return
+            }
+        }
+
+        do {
+            try await MainActor.run {
+                try adapter.applyRemote(persistence, payload)
+            }
+            let lastSynced = modifiedDate ?? Date()
+            var entityMetadata = recordMetadata[adapter.entity, default: [:]]
+            entityMetadata[payload.id] = SyncRecordMetadata(checksum: payload.checksum, lastSynced: lastSynced)
+            recordMetadata[adapter.entity] = entityMetadata
+            persistMetadata(for: adapter.entity)
+        } catch {
+            await updateStatus(.error(message: error.localizedDescription, lastSync: status.lastSyncDate))
+        }
+    }
+
+    private func applyRemoteDeletion(adapter: AnySyncAdapter, identifier: UUID) async {
+        do {
+            try await MainActor.run {
+                try adapter.deleteLocal(persistence, identifier)
+            }
+            var entityMetadata = recordMetadata[adapter.entity] ?? [:]
+            entityMetadata.removeValue(forKey: identifier)
+            recordMetadata[adapter.entity] = entityMetadata
+            persistMetadata(for: adapter.entity)
+        } catch {
+            await updateStatus(.error(message: error.localizedDescription, lastSync: status.lastSyncDate))
+        }
+    }
+
+    private func storeChangeToken(_ token: CKServerChangeToken?, for entity: SyncEntity) async {
+        if let token {
+            changeTokens[entity] = token
+        } else {
+            changeTokens.removeValue(forKey: entity)
+        }
+        persistChangeToken(token, for: entity)
+    }
+
+    private func collectLocalPayloads(adapters: [AnySyncAdapter]) async throws -> [SyncEntity: [SyncPayload]] {
+        var result: [SyncEntity: [SyncPayload]] = [:]
+        for adapter in adapters {
+            let payloads = try await MainActor.run {
+                try adapter.fetchLocal(persistence)
+            }
+            result[adapter.entity] = payloads
+        }
+        return result
+    }
+
+}
+
+private func checksum(for data: Data) -> String {
+    let hash = SHA256.hash(data: data)
+    return hash.map { String(format: "%02x", $0) }.joined()
 }

--- a/Core/Sync/SyncSnapshots.swift
+++ b/Core/Sync/SyncSnapshots.swift
@@ -1,0 +1,501 @@
+import Foundation
+
+private func unionOrdered<T: Hashable>(_ lhs: [T], _ rhs: [T]) -> [T] {
+    var seen: Set<T> = []
+    var result: [T] = []
+    for value in lhs + rhs {
+        if seen.insert(value).inserted {
+            result.append(value)
+        }
+    }
+    return result
+}
+
+struct AppUserSnapshot: Codable {
+    var identifier: UUID
+    var createdAt: Date
+
+    init(model: AppUser) {
+        self.identifier = model.identifier
+        self.createdAt = model.createdAt
+    }
+
+    func makeModel() -> AppUser {
+        AppUser(identifier: identifier, createdAt: createdAt)
+    }
+
+    func apply(to model: AppUser) {
+        model.createdAt = createdAt
+    }
+}
+
+struct AccountSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var type: String
+    var institution: String?
+    var lastSync: Date?
+
+    init(model: Account) {
+        self.id = model.id
+        self.name = model.name
+        self.type = model.type
+        self.institution = model.institution
+        self.lastSync = model.lastSync
+    }
+
+    func makeModel() throws -> Account {
+        try Account(id: id, name: name, type: type, institution: institution, lastSync: lastSync)
+    }
+
+    func apply(to model: Account) {
+        model.name = name
+        model.type = type
+        model.institution = institution
+        model.lastSync = lastSync
+    }
+}
+
+struct MerchantSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var category: String?
+    var address: String?
+
+    init(model: Merchant) {
+        self.id = model.id
+        self.name = model.name
+        self.category = model.category
+        self.address = model.address
+    }
+
+    func makeModel() throws -> Merchant {
+        try Merchant(id: id, name: name, category: category, address: address)
+    }
+
+    func apply(to model: Merchant) {
+        model.name = name
+        model.category = category
+        model.address = address
+    }
+}
+
+struct TransactionSnapshot: Codable {
+    var id: UUID
+    var accountId: UUID?
+    var amount: Decimal
+    var currency: String
+    var date: Date
+    var merchantId: UUID?
+    var tags: [String]
+    var source: String
+    var attachmentIds: [UUID]
+
+    init(model: Transaction) {
+        self.id = model.id
+        self.accountId = model.accountId
+        self.amount = model.amount
+        self.currency = model.currency
+        self.date = model.date
+        self.merchantId = model.merchantId
+        self.tags = model.tags
+        self.source = model.source
+        self.attachmentIds = model.attachmentIds
+    }
+
+    func makeModel() throws -> Transaction {
+        try Transaction(
+            id: id,
+            accountId: accountId,
+            amount: amount,
+            currency: currency,
+            date: date,
+            merchantId: merchantId,
+            tags: tags,
+            source: source,
+            attachmentIds: attachmentIds
+        )
+    }
+
+    func apply(to model: Transaction) {
+        model.accountId = accountId
+        model.amount = amount
+        model.currency = currency
+        model.date = date
+        model.merchantId = merchantId
+        model.tags = unionOrdered(model.tags, tags)
+        model.source = source
+        model.attachmentIds = unionOrdered(model.attachmentIds, attachmentIds)
+    }
+}
+
+struct InventoryItemSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var barcode: String?
+    var qty: Double
+    var unit: String
+    var locationId: UUID?
+    var expiry: Date?
+    var restockThreshold: Decimal
+    var tags: [String]
+    var lastPricePaid: Decimal?
+
+    init(model: InventoryItem) {
+        self.id = model.id
+        self.name = model.name
+        self.barcode = model.barcode
+        self.qty = model.qty
+        self.unit = model.unit
+        self.locationId = model.locationId
+        self.expiry = model.expiry
+        self.restockThreshold = model.restockThreshold
+        self.tags = model.tags
+        self.lastPricePaid = model.lastPricePaid
+    }
+
+    func makeModel() throws -> InventoryItem {
+        try InventoryItem(
+            id: id,
+            name: name,
+            barcode: barcode,
+            qty: qty,
+            unit: unit,
+            locationId: locationId,
+            expiry: expiry,
+            restockThreshold: restockThreshold,
+            tags: tags,
+            lastPricePaid: lastPricePaid
+        )
+    }
+
+    func apply(to model: InventoryItem) {
+        model.name = name
+        model.barcode = barcode
+        model.qty = qty
+        model.unit = unit
+        model.locationId = locationId
+        model.expiry = expiry
+        model.restockThreshold = restockThreshold
+        model.tags = unionOrdered(model.tags, tags)
+        model.lastPricePaid = lastPricePaid
+    }
+}
+
+struct LocationBinSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var kind: String
+
+    init(model: LocationBin) {
+        self.id = model.id
+        self.name = model.name
+        self.kind = model.kind
+    }
+
+    func makeModel() throws -> LocationBin {
+        try LocationBin(id: id, name: name, kind: kind)
+    }
+
+    func apply(to model: LocationBin) {
+        model.name = name
+        model.kind = kind
+    }
+}
+
+struct ShoppingListSnapshot: Codable {
+    var id: UUID
+    var name: String
+
+    init(model: ShoppingList) {
+        self.id = model.id
+        self.name = model.name
+    }
+
+    func makeModel() throws -> ShoppingList {
+        try ShoppingList(id: id, name: name)
+    }
+
+    func apply(to model: ShoppingList) {
+        model.name = name
+    }
+}
+
+struct ShoppingListLineSnapshot: Codable {
+    var id: UUID
+    var inventoryItemId: UUID?
+    var name: String
+    var desiredQty: Double
+    var status: String
+    var preferredMerchantId: UUID?
+    var listId: UUID?
+
+    init(model: ShoppingListLine) {
+        self.id = model.id
+        self.inventoryItemId = model.inventoryItemId
+        self.name = model.name
+        self.desiredQty = model.desiredQty
+        self.status = model.status
+        self.preferredMerchantId = model.preferredMerchantId
+        self.listId = model.list?.id
+    }
+
+    func makeModel(list: ShoppingList?) throws -> ShoppingListLine {
+        try ShoppingListLine(
+            id: id,
+            inventoryItemId: inventoryItemId,
+            name: name,
+            desiredQty: desiredQty,
+            status: status,
+            preferredMerchantId: preferredMerchantId,
+            list: list
+        )
+    }
+
+    func apply(to model: ShoppingListLine, list: ShoppingList?) {
+        model.inventoryItemId = inventoryItemId
+        model.name = name
+        model.desiredQty = desiredQty
+        model.status = status
+        model.preferredMerchantId = preferredMerchantId
+        model.list = list
+    }
+}
+
+struct HabitSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var scheduleRule: String
+    var unit: String
+    var target: Double
+    var streak: Int
+    var lastCheckIn: Date?
+
+    init(model: Habit) {
+        self.id = model.id
+        self.name = model.name
+        self.scheduleRule = model.scheduleRule
+        self.unit = model.unit
+        self.target = model.target
+        self.streak = model.streak
+        self.lastCheckIn = model.lastCheckIn
+    }
+
+    func makeModel() throws -> Habit {
+        try Habit(
+            id: id,
+            name: name,
+            scheduleRule: scheduleRule,
+            unit: unit,
+            target: target,
+            streak: streak,
+            lastCheckIn: lastCheckIn
+        )
+    }
+
+    func apply(to model: Habit) {
+        model.name = name
+        model.scheduleRule = scheduleRule
+        model.unit = unit
+        model.target = target
+        model.streak = streak
+        model.lastCheckIn = lastCheckIn
+    }
+}
+
+struct TaskLinkSnapshot: Codable {
+    var id: UUID
+    var reminderIdentifier: String
+    var relatedEntityRef: String
+
+    init(model: TaskLink) {
+        self.id = model.id
+        self.reminderIdentifier = model.reminderIdentifier
+        self.relatedEntityRef = model.relatedEntityRef
+    }
+
+    func makeModel() throws -> TaskLink {
+        try TaskLink(id: id, reminderIdentifier: reminderIdentifier, relatedEntityRef: relatedEntityRef)
+    }
+
+    func apply(to model: TaskLink) {
+        model.reminderIdentifier = reminderIdentifier
+        model.relatedEntityRef = relatedEntityRef
+    }
+}
+
+struct CalendarLinkSnapshot: Codable {
+    var id: UUID
+    var eventIdentifier: String
+    var relatedEntityRef: String
+
+    init(model: CalendarLink) {
+        self.id = model.id
+        self.eventIdentifier = model.eventIdentifier
+        self.relatedEntityRef = model.relatedEntityRef
+    }
+
+    func makeModel() throws -> CalendarLink {
+        try CalendarLink(id: id, eventIdentifier: eventIdentifier, relatedEntityRef: relatedEntityRef)
+    }
+
+    func apply(to model: CalendarLink) {
+        model.eventIdentifier = eventIdentifier
+        model.relatedEntityRef = relatedEntityRef
+    }
+}
+
+struct AttachmentSnapshot: Codable {
+    var id: UUID
+    var kind: String
+    var localURL: String
+    var ocrText: String?
+
+    init(model: Attachment) {
+        self.id = model.id
+        self.kind = model.kind
+        self.localURL = model.localURL.absoluteString
+        self.ocrText = model.ocrText
+    }
+
+    func makeModel() throws -> Attachment {
+        guard let url = URL(string: localURL) else {
+            throw URLError(.badURL)
+        }
+        return try Attachment(id: id, kind: kind, localURL: url, ocrText: ocrText)
+    }
+
+    func apply(to model: Attachment) {
+        model.kind = kind
+        if let url = URL(string: localURL) {
+            model.localURL = url
+        }
+        model.ocrText = ocrText
+    }
+}
+
+struct BudgetEnvelopeSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var monthlyLimit: Decimal
+    var currency: String
+    var tags: [String]
+    var notes: String?
+    var createdAt: Date
+
+    init(model: BudgetEnvelope) {
+        self.id = model.id
+        self.name = model.name
+        self.monthlyLimit = model.monthlyLimit
+        self.currency = model.currency
+        self.tags = model.tags
+        self.notes = model.notes
+        self.createdAt = model.createdAt
+    }
+
+    func makeModel() throws -> BudgetEnvelope {
+        try BudgetEnvelope(
+            id: id,
+            name: name,
+            monthlyLimit: monthlyLimit,
+            currency: currency,
+            tags: tags,
+            notes: notes,
+            createdAt: createdAt
+        )
+    }
+
+    func apply(to model: BudgetEnvelope) {
+        model.name = name
+        model.monthlyLimit = monthlyLimit
+        model.currency = currency
+        model.tags = unionOrdered(model.tags, tags)
+        model.notes = notes
+        model.createdAt = createdAt
+    }
+}
+
+struct PersonLinkSnapshot: Codable {
+    var id: UUID
+    var contactIdentifier: String
+    var role: String
+
+    init(model: PersonLink) {
+        self.id = model.id
+        self.contactIdentifier = model.contactIdentifier
+        self.role = model.role
+    }
+
+    func makeModel() throws -> PersonLink {
+        try PersonLink(id: id, contactIdentifier: contactIdentifier, role: role)
+    }
+
+    func apply(to model: PersonLink) {
+        model.contactIdentifier = contactIdentifier
+        model.role = role
+    }
+}
+
+struct RuleSpecSnapshot: Codable {
+    var id: UUID
+    var name: String
+    var trigger: String
+    var conditions: [String]
+    var actions: [String]
+    var enabled: Bool
+
+    init(model: RuleSpec) {
+        self.id = model.id
+        self.name = model.name
+        self.trigger = model.trigger
+        self.conditions = model.conditions
+        self.actions = model.actions
+        self.enabled = model.enabled
+    }
+
+    func makeModel() throws -> RuleSpec {
+        try RuleSpec(
+            id: id,
+            name: name,
+            trigger: trigger,
+            conditions: conditions,
+            actions: actions,
+            enabled: enabled
+        )
+    }
+
+    func apply(to model: RuleSpec) {
+        model.name = name
+        model.trigger = trigger
+        model.conditions = unionOrdered(model.conditions, conditions)
+        model.actions = unionOrdered(model.actions, actions)
+        model.enabled = enabled
+    }
+}
+
+struct EventRecordSnapshot: Codable {
+    var id: UUID
+    var kind: String
+    var payloadJSON: String
+    var occurredAt: Date
+    var relatedIds: [UUID]
+
+    init(model: EventRecord) {
+        self.id = model.id
+        self.kind = model.kind
+        self.payloadJSON = model.payloadJSON
+        self.occurredAt = model.occurredAt
+        self.relatedIds = model.relatedIds
+    }
+
+    func makeModel() throws -> EventRecord {
+        try EventRecord(id: id, kind: kind, payloadJSON: payloadJSON, occurredAt: occurredAt, relatedIds: relatedIds)
+    }
+
+    func apply(to model: EventRecord) {
+        model.kind = kind
+        model.payloadJSON = payloadJSON
+        model.occurredAt = occurredAt
+        model.relatedIds = unionOrdered(model.relatedIds, relatedIds)
+    }
+}

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -1,18 +1,63 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(\.services) private var services
+    @StateObject private var viewModel = SettingsViewModel()
+
     var body: some View {
         NavigationStack {
             Form {
-                Toggle(isOn: .constant(true)) {
-                    Label("iCloud Sync", systemImage: "icloud")
+                Section("iCloud") {
+                    Toggle(isOn: Binding(
+                        get: { viewModel.configuration.isEnabled },
+                        set: { viewModel.toggleSync($0) }
+                    )) {
+                        Label("iCloud Sync", systemImage: "icloud")
+                    }
+
+                    statusRow
+
+                    Button {
+                        viewModel.syncNow()
+                    } label: {
+                        Label("Sync Now", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(!viewModel.configuration.isEnabled || viewModel.status.isSyncing)
+                }
+
+                Section("Permissions") {
+                    ForEach(viewModel.availableFeatures) { feature in
+                        Toggle(isOn: Binding(
+                            get: { viewModel.isFeatureEnabled(feature) },
+                            set: { viewModel.toggleFeature(feature, isOn: $0) }
+                        )) {
+                            Label(feature.displayName, systemImage: feature.systemImageName)
+                        }
+                        .disabled(!viewModel.configuration.isEnabled)
+                    }
                 }
             }
             .navigationTitle("Settings")
         }
+        .task {
+            await viewModel.configureIfNeeded(syncService: services.sync)
+        }
+    }
+
+    private var statusRow: some View {
+        Label {
+            Text(viewModel.statusDescription)
+                .foregroundStyle(viewModel.statusColor)
+                .font(.footnote)
+        } icon: {
+            Image(systemName: viewModel.statusIconName)
+                .foregroundStyle(viewModel.statusColor)
+        }
+        .padding(.vertical, 2)
     }
 }
 
 #Preview {
     SettingsView()
+        .environment(\.services, ServiceContainer.makePreview())
 }

--- a/Features/Settings/SettingsViewModel.swift
+++ b/Features/Settings/SettingsViewModel.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published private(set) var configuration: SyncConfiguration
+    @Published private(set) var status: SyncStatus
+
+    private var syncService: SyncService?
+    private var configurationTask: Task<Void, Never>?
+    private var statusTask: Task<Void, Never>?
+    private let relativeFormatter: RelativeDateTimeFormatter
+
+    init(configuration: SyncConfiguration = SyncConfiguration(), status: SyncStatus = .disabled) {
+        self.configuration = configuration
+        self.status = status
+        self.relativeFormatter = RelativeDateTimeFormatter()
+        self.relativeFormatter.unitsStyle = .abbreviated
+    }
+
+    deinit {
+        configurationTask?.cancel()
+        statusTask?.cancel()
+    }
+
+    var availableFeatures: [SyncFeature] {
+        SyncFeature.allCases
+    }
+
+    func configureIfNeeded(syncService: SyncService) async {
+        guard self.syncService == nil else { return }
+        self.syncService = syncService
+        configuration = await syncService.currentConfiguration()
+        status = await syncService.currentStatus()
+
+        configurationTask = Task { [weak self] in
+            let stream = await syncService.configurationStream()
+            for await configuration in stream {
+                await MainActor.run {
+                    self?.configuration = configuration
+                }
+            }
+        }
+
+        statusTask = Task { [weak self] in
+            let stream = await syncService.statusStream()
+            for await status in stream {
+                await MainActor.run {
+                    self?.status = status
+                }
+            }
+        }
+    }
+
+    func toggleSync(_ isOn: Bool) {
+        configuration.setEnabled(isOn)
+        Task { [weak self] in
+            guard let self, let syncService = self.syncService else { return }
+            await syncService.setSyncEnabled(isOn)
+            if isOn {
+                await syncService.synchronize()
+            }
+        }
+    }
+
+    func toggleFeature(_ feature: SyncFeature, isOn: Bool) {
+        configuration.setFeature(feature, enabled: isOn)
+        Task { [weak self] in
+            guard let self, let syncService = self.syncService else { return }
+            await syncService.setFeature(feature, enabled: isOn)
+        }
+    }
+
+    func syncNow() {
+        Task { [weak self] in
+            guard let self, let syncService = self.syncService else { return }
+            await syncService.synchronize()
+        }
+    }
+
+    func isFeatureEnabled(_ feature: SyncFeature) -> Bool {
+        configuration.allows(feature)
+    }
+
+    var statusDescription: String {
+        switch status {
+        case .disabled:
+            return "Sync is turned off."
+        case .syncing:
+            return "Syncing with iCloud…"
+        case let .idle(lastSync):
+            if let lastSync {
+                return "Last synced \(relativeFormatter.localizedString(for: lastSync, relativeTo: .now))."
+            } else {
+                return "Awaiting first sync."
+            }
+        case let .error(message, lastSync):
+            if let lastSync {
+                let relative = relativeFormatter.localizedString(for: lastSync, relativeTo: .now)
+                return "Error: \(message). Last successful sync \(relative)."
+            } else {
+                return "Error: \(message)."
+            }
+        }
+    }
+
+    var statusIconName: String {
+        switch status {
+        case .disabled:
+            return "icloud.slash"
+        case .syncing:
+            return "arrow.triangle.2.circlepath"
+        case .idle:
+            return "checkmark.icloud"
+        case .error:
+            return "exclamationmark.triangle"
+        }
+    }
+
+    var statusColor: Color {
+        switch status {
+        case .disabled:
+            return .secondary
+        case .syncing:
+            return .accentColor
+        case .idle:
+            return .secondary
+        case .error:
+            return .red
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a CloudKit-backed SyncService with per-entity tokens, conflict resolution, and offline handling
- add sync snapshot models and a settings view model/UI to expose sync state and per-feature permissions
- wire the sync service through the app composition and service container so it is available to views and intents

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d04fb7eaf88329ae869e4fbe272341